### PR TITLE
feat: unified comment operations across commit and PR contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Authentication workflow:
 - `go run ./cmd/bbsc diff refs main feature --repo TEST/my-repo`
 - `go run ./cmd/bbsc diff pr 123 --repo TEST/my-repo --patch`
 - `go run ./cmd/bbsc diff commit <sha> --repo TEST/my-repo --path seed.txt`
+- `go run ./cmd/bbsc repo comment list --repo TEST/my-repo --commit <sha> --path seed.txt`
+- `go run ./cmd/bbsc repo comment create --repo TEST/my-repo --pr 123 --text "Looks good"`
+- `go run ./cmd/bbsc repo comment update --repo TEST/my-repo --commit <sha> --id 42 --text "Updated text"`
+- `go run ./cmd/bbsc repo comment delete --repo TEST/my-repo --pr 123 --id 42`
 
 Runtime config precedence:
 

--- a/internal/services/comment/service.go
+++ b/internal/services/comment/service.go
@@ -1,0 +1,347 @@
+package comment
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
+	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
+)
+
+type RepositoryRef struct {
+	ProjectKey string
+	Slug       string
+}
+
+type Context struct {
+	Type           string `json:"type"`
+	ProjectKey     string `json:"project_key"`
+	RepositorySlug string `json:"repository_slug"`
+	CommitID       string `json:"commit_id,omitempty"`
+	PullRequestID  string `json:"pull_request_id,omitempty"`
+}
+
+type Target struct {
+	Repository    RepositoryRef
+	CommitID      string
+	PullRequestID string
+}
+
+func (target Target) Context() Context {
+	ctx := Context{
+		ProjectKey:     target.Repository.ProjectKey,
+		RepositorySlug: target.Repository.Slug,
+	}
+
+	if strings.TrimSpace(target.CommitID) != "" {
+		ctx.Type = "commit"
+		ctx.CommitID = target.CommitID
+		return ctx
+	}
+
+	ctx.Type = "pull_request"
+	ctx.PullRequestID = target.PullRequestID
+	return ctx
+}
+
+type Service struct {
+	client *openapigenerated.ClientWithResponses
+}
+
+func NewService(client *openapigenerated.ClientWithResponses) *Service {
+	return &Service{client: client}
+}
+
+func (service *Service) List(ctx context.Context, target Target, path string, limit int) ([]openapigenerated.RestComment, error) {
+	if err := validateTarget(target); err != nil {
+		return nil, err
+	}
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" {
+		return nil, apperrors.New(apperrors.KindValidation, "comment path is required for list operations", nil)
+	}
+	if limit <= 0 {
+		limit = 25
+	}
+
+	start := float32(0)
+	pageLimit := float32(limit)
+	results := make([]openapigenerated.RestComment, 0)
+
+	for {
+		if strings.TrimSpace(target.CommitID) != "" {
+			response, err := service.client.GetCommentsWithResponse(ctx, target.Repository.ProjectKey, target.Repository.Slug, target.CommitID, &openapigenerated.GetCommentsParams{Path: &trimmedPath, Start: &start, Limit: &pageLimit})
+			if err != nil {
+				return nil, apperrors.New(apperrors.KindTransient, "failed to list commit comments", err)
+			}
+			if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+				return nil, err
+			}
+			if response.ApplicationjsonCharsetUTF8200 == nil || response.ApplicationjsonCharsetUTF8200.Values == nil {
+				break
+			}
+
+			results = append(results, (*response.ApplicationjsonCharsetUTF8200.Values)...)
+			if response.ApplicationjsonCharsetUTF8200.IsLastPage != nil && *response.ApplicationjsonCharsetUTF8200.IsLastPage {
+				break
+			}
+			if response.ApplicationjsonCharsetUTF8200.NextPageStart == nil {
+				break
+			}
+			start = float32(*response.ApplicationjsonCharsetUTF8200.NextPageStart)
+			continue
+		}
+
+		response, err := service.client.GetComments2WithResponse(ctx, target.Repository.ProjectKey, target.Repository.Slug, target.PullRequestID, &openapigenerated.GetComments2Params{Path: trimmedPath, Start: &start, Limit: &pageLimit})
+		if err != nil {
+			return nil, apperrors.New(apperrors.KindTransient, "failed to list pull request comments", err)
+		}
+		if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+			return nil, err
+		}
+		if response.ApplicationjsonCharsetUTF8200 == nil || response.ApplicationjsonCharsetUTF8200.Values == nil {
+			break
+		}
+
+		results = append(results, (*response.ApplicationjsonCharsetUTF8200.Values)...)
+		if response.ApplicationjsonCharsetUTF8200.IsLastPage != nil && *response.ApplicationjsonCharsetUTF8200.IsLastPage {
+			break
+		}
+		if response.ApplicationjsonCharsetUTF8200.NextPageStart == nil {
+			break
+		}
+		start = float32(*response.ApplicationjsonCharsetUTF8200.NextPageStart)
+	}
+
+	return results, nil
+}
+
+func (service *Service) Create(ctx context.Context, target Target, text string) (openapigenerated.RestComment, error) {
+	if err := validateTarget(target); err != nil {
+		return openapigenerated.RestComment{}, err
+	}
+
+	trimmedText := strings.TrimSpace(text)
+	if trimmedText == "" {
+		return openapigenerated.RestComment{}, apperrors.New(apperrors.KindValidation, "comment text is required", nil)
+	}
+
+	body := openapigenerated.RestComment{Text: &trimmedText}
+
+	if strings.TrimSpace(target.CommitID) != "" {
+		response, err := service.client.CreateCommentWithResponse(ctx, target.Repository.ProjectKey, target.Repository.Slug, target.CommitID, nil, body)
+		if err != nil {
+			return openapigenerated.RestComment{}, apperrors.New(apperrors.KindTransient, "failed to create commit comment", err)
+		}
+		if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+			return openapigenerated.RestComment{}, err
+		}
+		if response.ApplicationjsonCharsetUTF8201 != nil {
+			return *response.ApplicationjsonCharsetUTF8201, nil
+		}
+		return body, nil
+	}
+
+	response, err := service.client.CreateComment2WithResponse(ctx, target.Repository.ProjectKey, target.Repository.Slug, target.PullRequestID, body)
+	if err != nil {
+		return openapigenerated.RestComment{}, apperrors.New(apperrors.KindTransient, "failed to create pull request comment", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return openapigenerated.RestComment{}, err
+	}
+	if response.ApplicationjsonCharsetUTF8201 != nil {
+		return *response.ApplicationjsonCharsetUTF8201, nil
+	}
+
+	return body, nil
+}
+
+func (service *Service) Update(ctx context.Context, target Target, commentID string, text string, version *int32) (openapigenerated.RestComment, error) {
+	if err := validateTarget(target); err != nil {
+		return openapigenerated.RestComment{}, err
+	}
+
+	trimmedCommentID := strings.TrimSpace(commentID)
+	if trimmedCommentID == "" {
+		return openapigenerated.RestComment{}, apperrors.New(apperrors.KindValidation, "comment id is required", nil)
+	}
+
+	trimmedText := strings.TrimSpace(text)
+	if trimmedText == "" {
+		return openapigenerated.RestComment{}, apperrors.New(apperrors.KindValidation, "comment text is required", nil)
+	}
+
+	resolvedVersion := version
+	if resolvedVersion == nil {
+		current, err := service.Get(ctx, target, trimmedCommentID)
+		if err != nil {
+			return openapigenerated.RestComment{}, err
+		}
+		resolvedVersion = current.Version
+	}
+
+	body := openapigenerated.RestComment{Text: &trimmedText, Version: resolvedVersion}
+
+	if strings.TrimSpace(target.CommitID) != "" {
+		response, err := service.client.UpdateCommentWithResponse(ctx, target.Repository.ProjectKey, target.Repository.Slug, target.CommitID, trimmedCommentID, body)
+		if err != nil {
+			return openapigenerated.RestComment{}, apperrors.New(apperrors.KindTransient, "failed to update commit comment", err)
+		}
+		if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+			return openapigenerated.RestComment{}, err
+		}
+		if response.ApplicationjsonCharsetUTF8200 != nil {
+			return *response.ApplicationjsonCharsetUTF8200, nil
+		}
+		return body, nil
+	}
+
+	response, err := service.client.UpdateComment2WithResponse(ctx, target.Repository.ProjectKey, target.Repository.Slug, target.PullRequestID, trimmedCommentID, body)
+	if err != nil {
+		return openapigenerated.RestComment{}, apperrors.New(apperrors.KindTransient, "failed to update pull request comment", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return openapigenerated.RestComment{}, err
+	}
+	if response.ApplicationjsonCharsetUTF8200 != nil {
+		return *response.ApplicationjsonCharsetUTF8200, nil
+	}
+
+	return body, nil
+}
+
+func (service *Service) Delete(ctx context.Context, target Target, commentID string, version *int32) (*int32, error) {
+	if err := validateTarget(target); err != nil {
+		return nil, err
+	}
+
+	trimmedCommentID := strings.TrimSpace(commentID)
+	if trimmedCommentID == "" {
+		return nil, apperrors.New(apperrors.KindValidation, "comment id is required", nil)
+	}
+
+	resolvedVersion := version
+	if resolvedVersion == nil {
+		current, err := service.Get(ctx, target, trimmedCommentID)
+		if err != nil {
+			return nil, err
+		}
+		resolvedVersion = current.Version
+	}
+
+	var versionParam *string
+	if resolvedVersion != nil {
+		value := strconv.Itoa(int(*resolvedVersion))
+		versionParam = &value
+	}
+
+	if strings.TrimSpace(target.CommitID) != "" {
+		response, err := service.client.DeleteCommentWithResponse(ctx, target.Repository.ProjectKey, target.Repository.Slug, target.CommitID, trimmedCommentID, &openapigenerated.DeleteCommentParams{Version: versionParam})
+		if err != nil {
+			return nil, apperrors.New(apperrors.KindTransient, "failed to delete commit comment", err)
+		}
+		if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+			return nil, err
+		}
+		return resolvedVersion, nil
+	}
+
+	response, err := service.client.DeleteComment2WithResponse(ctx, target.Repository.ProjectKey, target.Repository.Slug, target.PullRequestID, trimmedCommentID, &openapigenerated.DeleteComment2Params{Version: versionParam})
+	if err != nil {
+		return nil, apperrors.New(apperrors.KindTransient, "failed to delete pull request comment", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return nil, err
+	}
+
+	return resolvedVersion, nil
+}
+
+func (service *Service) Get(ctx context.Context, target Target, commentID string) (openapigenerated.RestComment, error) {
+	if err := validateTarget(target); err != nil {
+		return openapigenerated.RestComment{}, err
+	}
+
+	trimmedCommentID := strings.TrimSpace(commentID)
+	if trimmedCommentID == "" {
+		return openapigenerated.RestComment{}, apperrors.New(apperrors.KindValidation, "comment id is required", nil)
+	}
+
+	if strings.TrimSpace(target.CommitID) != "" {
+		response, err := service.client.GetCommentWithResponse(ctx, target.Repository.ProjectKey, target.Repository.Slug, target.CommitID, trimmedCommentID)
+		if err != nil {
+			return openapigenerated.RestComment{}, apperrors.New(apperrors.KindTransient, "failed to get commit comment", err)
+		}
+		if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+			return openapigenerated.RestComment{}, err
+		}
+		if response.ApplicationjsonCharsetUTF8200 != nil {
+			return *response.ApplicationjsonCharsetUTF8200, nil
+		}
+		return openapigenerated.RestComment{}, nil
+	}
+
+	response, err := service.client.GetComment2WithResponse(ctx, target.Repository.ProjectKey, target.Repository.Slug, target.PullRequestID, trimmedCommentID)
+	if err != nil {
+		return openapigenerated.RestComment{}, apperrors.New(apperrors.KindTransient, "failed to get pull request comment", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return openapigenerated.RestComment{}, err
+	}
+	if response.ApplicationjsonCharsetUTF8200 != nil {
+		return *response.ApplicationjsonCharsetUTF8200, nil
+	}
+
+	return openapigenerated.RestComment{}, nil
+}
+
+func validateTarget(target Target) error {
+	if strings.TrimSpace(target.Repository.ProjectKey) == "" || strings.TrimSpace(target.Repository.Slug) == "" {
+		return apperrors.New(apperrors.KindValidation, "repository must be specified as project/repo", nil)
+	}
+
+	hasCommit := strings.TrimSpace(target.CommitID) != ""
+	hasPullRequest := strings.TrimSpace(target.PullRequestID) != ""
+
+	if hasCommit == hasPullRequest {
+		return apperrors.New(apperrors.KindValidation, "exactly one of commit or pull request id is required", nil)
+	}
+
+	return nil
+}
+
+func mapStatusError(status int, body []byte) error {
+	if status >= 200 && status < 300 {
+		return nil
+	}
+
+	message := strings.TrimSpace(string(body))
+	if message == "" {
+		message = http.StatusText(status)
+	}
+
+	baseMessage := fmt.Sprintf("bitbucket API returned %d: %s", status, message)
+
+	switch status {
+	case http.StatusBadRequest:
+		return apperrors.New(apperrors.KindValidation, baseMessage, nil)
+	case http.StatusUnauthorized:
+		return apperrors.New(apperrors.KindAuthentication, baseMessage, nil)
+	case http.StatusForbidden:
+		return apperrors.New(apperrors.KindAuthorization, baseMessage, nil)
+	case http.StatusNotFound:
+		return apperrors.New(apperrors.KindNotFound, baseMessage, nil)
+	case http.StatusConflict:
+		return apperrors.New(apperrors.KindConflict, baseMessage, nil)
+	case http.StatusTooManyRequests:
+		return apperrors.New(apperrors.KindTransient, baseMessage, nil)
+	default:
+		if status >= 500 {
+			return apperrors.New(apperrors.KindTransient, baseMessage, nil)
+		}
+		return apperrors.New(apperrors.KindPermanent, baseMessage, nil)
+	}
+}

--- a/tests/integration/live/comment_live_test.go
+++ b/tests/integration/live/comment_live_test.go
@@ -1,0 +1,116 @@
+//go:build live
+
+package live_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	commentservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/comment"
+)
+
+func TestLiveCommentFlowCommit(t *testing.T) {
+	harness := newLiveHarness(t)
+	service := commentservice.NewService(harness.client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	seeded, err := harness.seedProjectWithRepositories(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("seed project with repositories failed: %v", err)
+	}
+
+	repo := seeded.Repos[0]
+	target := commentservice.Target{
+		Repository: commentservice.RepositoryRef{ProjectKey: seeded.Key, Slug: repo.Slug},
+		CommitID:   repo.CommitIDs[0],
+	}
+
+	created, err := service.Create(ctx, target, "live commit comment")
+	if err != nil {
+		t.Fatalf("create commit comment failed: %v", err)
+	}
+	if created.Id == nil {
+		t.Fatal("created commit comment missing id")
+	}
+
+	fetched, err := service.Get(ctx, target, fmt.Sprintf("%d", *created.Id))
+	if err != nil {
+		t.Fatalf("get commit comment failed: %v", err)
+	}
+	if fetched.Id == nil || *fetched.Id != *created.Id {
+		t.Fatalf("expected fetched commit comment id=%d, got %#v", *created.Id, fetched.Id)
+	}
+
+	updated, err := service.Update(ctx, target, fmt.Sprintf("%d", *created.Id), "live commit comment updated", nil)
+	if err != nil {
+		t.Fatalf("update commit comment failed: %v", err)
+	}
+	if updated.Text == nil || *updated.Text != "live commit comment updated" {
+		t.Fatalf("expected updated text, got: %#v", updated.Text)
+	}
+
+	if _, err := service.Delete(ctx, target, fmt.Sprintf("%d", *created.Id), nil); err != nil {
+		t.Fatalf("delete commit comment failed: %v", err)
+	}
+}
+
+func TestLiveCommentFlowPullRequest(t *testing.T) {
+	harness := newLiveHarness(t)
+	service := commentservice.NewService(harness.client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	seeded, err := harness.seedProjectWithRepositories(ctx, 1, 1)
+	if err != nil {
+		t.Fatalf("seed project with repositories failed: %v", err)
+	}
+
+	repo := seeded.Repos[0]
+	branch := fmt.Sprintf("lt-comment-%d", time.Now().UnixNano()%100000)
+	if err := harness.pushCommitOnBranch(seeded.Key, repo.Slug, branch, "comment-feature.txt"); err != nil {
+		t.Fatalf("push commit on branch failed: %v", err)
+	}
+
+	pullRequestID, err := harness.createPullRequest(ctx, seeded.Key, repo.Slug, branch, "master")
+	if err != nil {
+		t.Fatalf("create pull request failed: %v", err)
+	}
+
+	target := commentservice.Target{
+		Repository:    commentservice.RepositoryRef{ProjectKey: seeded.Key, Slug: repo.Slug},
+		PullRequestID: pullRequestID,
+	}
+
+	created, err := service.Create(ctx, target, "live pull request comment")
+	if err != nil {
+		t.Fatalf("create pull request comment failed: %v", err)
+	}
+	if created.Id == nil {
+		t.Fatal("created pull request comment missing id")
+	}
+
+	fetched, err := service.Get(ctx, target, fmt.Sprintf("%d", *created.Id))
+	if err != nil {
+		t.Fatalf("get pull request comment failed: %v", err)
+	}
+	if fetched.Id == nil || *fetched.Id != *created.Id {
+		t.Fatalf("expected fetched pull request comment id=%d, got %#v", *created.Id, fetched.Id)
+	}
+
+	updated, err := service.Update(ctx, target, fmt.Sprintf("%d", *created.Id), "live pull request comment updated", nil)
+	if err != nil {
+		t.Fatalf("update pull request comment failed: %v", err)
+	}
+	if updated.Text == nil || *updated.Text != "live pull request comment updated" {
+		t.Fatalf("expected updated text, got: %#v", updated.Text)
+	}
+
+	if _, err := service.Delete(ctx, target, fmt.Sprintf("%d", *created.Id), nil); err != nil {
+		t.Fatalf("delete pull request comment failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add unified comment service for commit + pull request contexts (list/create/get/update/delete)
- add CLI  verbs with shared context flags and explicit JSON context payload
- add unit tests for commit/PR comment command flows and live seeded integration tests for both contexts
- document new comment commands in README

## Notes
- aligns with ADR-013 by using  command grouping rather than introducing a new top-level command
-  requires  to match observed Bitbucket live behavior

Closes #3