### PR TITLE
feat: add tag lifecycle and build/insights automation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Authentication workflow:
 - `go run ./cmd/bbsc repo comment create --repo TEST/my-repo --pr 123 --text "Looks good"`
 - `go run ./cmd/bbsc repo comment update --repo TEST/my-repo --commit <sha> --id 42 --text "Updated text"`
 - `go run ./cmd/bbsc repo comment delete --repo TEST/my-repo --pr 123 --id 42`
+- `go run ./cmd/bbsc tag list --repo TEST/my-repo --limit 50 --order-by ALPHABETICAL`
+- `go run ./cmd/bbsc tag create v1.2.3 --repo TEST/my-repo --start-point <sha> --message "release v1.2.3"`
+- `go run ./cmd/bbsc tag view v1.2.3 --repo TEST/my-repo`
+- `go run ./cmd/bbsc tag delete v1.2.3 --repo TEST/my-repo`
+- `go run ./cmd/bbsc build status set <sha> --key ci/main --state SUCCESSFUL --url https://ci.example/build/42`
+- `go run ./cmd/bbsc build status get <sha> --order-by NEWEST --limit 25`
+- `go run ./cmd/bbsc build status stats <sha> --include-unique`
+- `go run ./cmd/bbsc build required list --repo TEST/my-repo`
+- `go run ./cmd/bbsc build required create --repo TEST/my-repo --body '{"buildParentKeys":["ci"],"refMatcher":{"id":"refs/heads/master"}}'`
+- `go run ./cmd/bbsc insights report set <sha> lint --repo TEST/my-repo --body '{"title":"Lint","result":"PASS","data":[{"title":"warnings","type":"NUMBER","value":{"value":0}}]}'`
+- `go run ./cmd/bbsc insights report get <sha> lint --repo TEST/my-repo`
+- `go run ./cmd/bbsc insights annotation add <sha> lint --repo TEST/my-repo --body '[{"externalId":"lint-1","message":"Fix warning","severity":"MEDIUM","path":"seed.txt","line":1}]'`
 
 Runtime config precedence:
 

--- a/internal/services/quality/service.go
+++ b/internal/services/quality/service.go
@@ -1,0 +1,568 @@
+package quality
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
+	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
+)
+
+type RepositoryRef struct {
+	ProjectKey string
+	Slug       string
+}
+
+type BuildStatusSetInput struct {
+	Key         string
+	State       string
+	URL         string
+	Name        string
+	Description string
+	Ref         string
+	Parent      string
+	BuildNumber string
+	DurationMS  int64
+}
+
+type Service struct {
+	client *openapigenerated.ClientWithResponses
+}
+
+func NewService(client *openapigenerated.ClientWithResponses) *Service {
+	return &Service{client: client}
+}
+
+func (service *Service) SetBuildStatus(ctx context.Context, commitID string, input BuildStatusSetInput) error {
+	trimmedCommitID := strings.TrimSpace(commitID)
+	if trimmedCommitID == "" {
+		return apperrors.New(apperrors.KindValidation, "commit id is required", nil)
+	}
+
+	trimmedKey := strings.TrimSpace(input.Key)
+	trimmedState := strings.TrimSpace(input.State)
+	trimmedURL := strings.TrimSpace(input.URL)
+	if trimmedKey == "" {
+		return apperrors.New(apperrors.KindValidation, "build status key is required", nil)
+	}
+	if trimmedState == "" {
+		return apperrors.New(apperrors.KindValidation, "build status state is required", nil)
+	}
+	if trimmedURL == "" {
+		return apperrors.New(apperrors.KindValidation, "build status url is required", nil)
+	}
+
+	state := openapigenerated.RestBuildStatusState(strings.ToUpper(trimmedState))
+	body := openapigenerated.AddBuildStatusJSONRequestBody{
+		Key:   &trimmedKey,
+		State: &state,
+		Url:   &trimmedURL,
+	}
+
+	if strings.TrimSpace(input.Name) != "" {
+		trimmedName := strings.TrimSpace(input.Name)
+		body.Name = &trimmedName
+	}
+	if strings.TrimSpace(input.Description) != "" {
+		trimmedDescription := strings.TrimSpace(input.Description)
+		body.Description = &trimmedDescription
+	}
+	if strings.TrimSpace(input.Ref) != "" {
+		trimmedRef := strings.TrimSpace(input.Ref)
+		body.Ref = &trimmedRef
+	}
+	if strings.TrimSpace(input.Parent) != "" {
+		trimmedParent := strings.TrimSpace(input.Parent)
+		body.Parent = &trimmedParent
+	}
+	if strings.TrimSpace(input.BuildNumber) != "" {
+		trimmedBuildNumber := strings.TrimSpace(input.BuildNumber)
+		body.BuildNumber = &trimmedBuildNumber
+	}
+	if input.DurationMS > 0 {
+		duration := input.DurationMS
+		body.Duration = &duration
+	}
+
+	response, err := service.client.AddBuildStatusWithResponse(ctx, trimmedCommitID, body)
+	if err != nil {
+		return apperrors.New(apperrors.KindTransient, "failed to set build status", err)
+	}
+
+	return mapStatusError(response.StatusCode(), response.Body)
+}
+
+func (service *Service) GetBuildStatuses(ctx context.Context, commitID string, limit int, orderBy string) ([]openapigenerated.RestBuildStatus, error) {
+	trimmedCommitID := strings.TrimSpace(commitID)
+	if trimmedCommitID == "" {
+		return nil, apperrors.New(apperrors.KindValidation, "commit id is required", nil)
+	}
+	if limit <= 0 {
+		limit = 25
+	}
+
+	start := float32(0)
+	pageLimit := float32(limit)
+	statuses := make([]openapigenerated.RestBuildStatus, 0)
+
+	for {
+		params := &openapigenerated.GetBuildStatusParams{Start: &start, Limit: &pageLimit}
+		if strings.TrimSpace(orderBy) != "" {
+			resolvedOrderBy := strings.TrimSpace(orderBy)
+			params.OrderBy = &resolvedOrderBy
+		}
+
+		response, err := service.client.GetBuildStatusWithResponse(ctx, trimmedCommitID, params)
+		if err != nil {
+			return nil, apperrors.New(apperrors.KindTransient, "failed to get build statuses", err)
+		}
+		if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+			return nil, err
+		}
+		if response.JSON200 == nil || response.JSON200.Values == nil {
+			break
+		}
+
+		statuses = append(statuses, (*response.JSON200.Values)...)
+
+		if response.JSON200.IsLastPage != nil && *response.JSON200.IsLastPage {
+			break
+		}
+		if response.JSON200.NextPageStart == nil {
+			break
+		}
+
+		start = float32(*response.JSON200.NextPageStart)
+	}
+
+	return statuses, nil
+}
+
+func (service *Service) GetBuildStatusStats(ctx context.Context, commitID string, includeUnique bool) (openapigenerated.RestBuildStats, error) {
+	trimmedCommitID := strings.TrimSpace(commitID)
+	if trimmedCommitID == "" {
+		return openapigenerated.RestBuildStats{}, apperrors.New(apperrors.KindValidation, "commit id is required", nil)
+	}
+
+	params := &openapigenerated.GetBuildStatusStatsParams{IncludeUnique: &includeUnique}
+	response, err := service.client.GetBuildStatusStatsWithResponse(ctx, trimmedCommitID, params)
+	if err != nil {
+		return openapigenerated.RestBuildStats{}, apperrors.New(apperrors.KindTransient, "failed to get build status stats", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return openapigenerated.RestBuildStats{}, err
+	}
+
+	if response.JSON200 != nil {
+		return *response.JSON200, nil
+	}
+
+	return openapigenerated.RestBuildStats{}, nil
+}
+
+func (service *Service) ListRequiredBuildChecks(ctx context.Context, repo RepositoryRef, limit int) ([]openapigenerated.RestRequiredBuildCondition, error) {
+	if err := validateRepositoryRef(repo); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 25
+	}
+
+	start := float32(0)
+	pageLimit := float32(limit)
+	checks := make([]openapigenerated.RestRequiredBuildCondition, 0)
+
+	for {
+		response, err := service.client.GetPageOfRequiredBuildsMergeChecksWithResponse(
+			ctx,
+			repo.ProjectKey,
+			repo.Slug,
+			&openapigenerated.GetPageOfRequiredBuildsMergeChecksParams{Start: &start, Limit: &pageLimit},
+		)
+		if err != nil {
+			return nil, apperrors.New(apperrors.KindTransient, "failed to list required build merge checks", err)
+		}
+		if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+			return nil, err
+		}
+		if response.ApplicationjsonCharsetUTF8200 == nil || response.ApplicationjsonCharsetUTF8200.Values == nil {
+			break
+		}
+
+		checks = append(checks, (*response.ApplicationjsonCharsetUTF8200.Values)...)
+
+		if response.ApplicationjsonCharsetUTF8200.IsLastPage != nil && *response.ApplicationjsonCharsetUTF8200.IsLastPage {
+			break
+		}
+		if response.ApplicationjsonCharsetUTF8200.NextPageStart == nil {
+			break
+		}
+
+		start = float32(*response.ApplicationjsonCharsetUTF8200.NextPageStart)
+	}
+
+	return checks, nil
+}
+
+func (service *Service) CreateRequiredBuildCheck(ctx context.Context, repo RepositoryRef, payload map[string]any) (map[string]any, error) {
+	if err := validateRepositoryRef(repo); err != nil {
+		return nil, err
+	}
+
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		return nil, apperrors.New(apperrors.KindValidation, "invalid required build check payload", err)
+	}
+
+	response, err := service.client.CreateRequiredBuildsMergeCheckWithBodyWithResponse(
+		ctx,
+		repo.ProjectKey,
+		repo.Slug,
+		"application/json",
+		bytes.NewReader(rawPayload),
+	)
+	if err != nil {
+		return nil, apperrors.New(apperrors.KindTransient, "failed to create required build merge check", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return nil, err
+	}
+
+	if response.ApplicationjsonCharsetUTF8200 == nil {
+		return map[string]any{}, nil
+	}
+
+	encoded, err := json.Marshal(response.ApplicationjsonCharsetUTF8200)
+	if err != nil {
+		return nil, apperrors.New(apperrors.KindInternal, "failed to encode required build merge check response", err)
+	}
+
+	parsed := map[string]any{}
+	if err := json.Unmarshal(encoded, &parsed); err != nil {
+		return nil, apperrors.New(apperrors.KindPermanent, "failed to decode required build merge check response", err)
+	}
+
+	return parsed, nil
+}
+
+func (service *Service) UpdateRequiredBuildCheck(ctx context.Context, repo RepositoryRef, id int64, payload map[string]any) (map[string]any, error) {
+	if err := validateRepositoryRef(repo); err != nil {
+		return nil, err
+	}
+	if id <= 0 {
+		return nil, apperrors.New(apperrors.KindValidation, "required build merge check id must be > 0", nil)
+	}
+
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		return nil, apperrors.New(apperrors.KindValidation, "invalid required build merge check payload", err)
+	}
+
+	response, err := service.client.UpdateRequiredBuildsMergeCheckWithBodyWithResponse(
+		ctx,
+		repo.ProjectKey,
+		repo.Slug,
+		id,
+		"application/json",
+		bytes.NewReader(rawPayload),
+	)
+	if err != nil {
+		return nil, apperrors.New(apperrors.KindTransient, "failed to update required build merge check", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return nil, err
+	}
+
+	if response.ApplicationjsonCharsetUTF8200 == nil {
+		return map[string]any{}, nil
+	}
+
+	encoded, err := json.Marshal(response.ApplicationjsonCharsetUTF8200)
+	if err != nil {
+		return nil, apperrors.New(apperrors.KindInternal, "failed to encode required build merge check response", err)
+	}
+
+	parsed := map[string]any{}
+	if err := json.Unmarshal(encoded, &parsed); err != nil {
+		return nil, apperrors.New(apperrors.KindPermanent, "failed to decode required build merge check response", err)
+	}
+
+	return parsed, nil
+}
+
+func (service *Service) DeleteRequiredBuildCheck(ctx context.Context, repo RepositoryRef, id int64) error {
+	if err := validateRepositoryRef(repo); err != nil {
+		return err
+	}
+	if id <= 0 {
+		return apperrors.New(apperrors.KindValidation, "required build merge check id must be > 0", nil)
+	}
+
+	response, err := service.client.DeleteRequiredBuildsMergeCheckWithResponse(ctx, repo.ProjectKey, repo.Slug, id)
+	if err != nil {
+		return apperrors.New(apperrors.KindTransient, "failed to delete required build merge check", err)
+	}
+
+	return mapStatusError(response.StatusCode(), response.Body)
+}
+
+func (service *Service) ListReports(ctx context.Context, repo RepositoryRef, commitID string, limit int) ([]openapigenerated.RestInsightReport, error) {
+	if err := validateRepositoryRef(repo); err != nil {
+		return nil, err
+	}
+	trimmedCommitID := strings.TrimSpace(commitID)
+	if trimmedCommitID == "" {
+		return nil, apperrors.New(apperrors.KindValidation, "commit id is required", nil)
+	}
+	if limit <= 0 {
+		limit = 25
+	}
+
+	start := float32(0)
+	pageLimit := float32(limit)
+	reports := make([]openapigenerated.RestInsightReport, 0)
+
+	for {
+		response, err := service.client.GetReportsWithResponse(
+			ctx,
+			repo.ProjectKey,
+			repo.Slug,
+			trimmedCommitID,
+			&openapigenerated.GetReportsParams{Start: &start, Limit: &pageLimit},
+		)
+		if err != nil {
+			return nil, apperrors.New(apperrors.KindTransient, "failed to list code insights reports", err)
+		}
+		if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+			return nil, err
+		}
+		if response.ApplicationjsonCharsetUTF8200 == nil || response.ApplicationjsonCharsetUTF8200.Values == nil {
+			break
+		}
+
+		reports = append(reports, (*response.ApplicationjsonCharsetUTF8200.Values)...)
+
+		if response.ApplicationjsonCharsetUTF8200.IsLastPage != nil && *response.ApplicationjsonCharsetUTF8200.IsLastPage {
+			break
+		}
+		if response.ApplicationjsonCharsetUTF8200.NextPageStart == nil {
+			break
+		}
+
+		start = float32(*response.ApplicationjsonCharsetUTF8200.NextPageStart)
+	}
+
+	return reports, nil
+}
+
+func (service *Service) SetReport(ctx context.Context, repo RepositoryRef, commitID string, key string, request openapigenerated.SetACodeInsightsReportJSONRequestBody) (openapigenerated.RestInsightReport, error) {
+	if err := validateRepositoryRef(repo); err != nil {
+		return openapigenerated.RestInsightReport{}, err
+	}
+
+	trimmedCommitID := strings.TrimSpace(commitID)
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedCommitID == "" {
+		return openapigenerated.RestInsightReport{}, apperrors.New(apperrors.KindValidation, "commit id is required", nil)
+	}
+	if trimmedKey == "" {
+		return openapigenerated.RestInsightReport{}, apperrors.New(apperrors.KindValidation, "report key is required", nil)
+	}
+
+	response, err := service.client.SetACodeInsightsReportWithResponse(ctx, repo.ProjectKey, repo.Slug, trimmedCommitID, trimmedKey, request)
+	if err != nil {
+		return openapigenerated.RestInsightReport{}, apperrors.New(apperrors.KindTransient, "failed to set code insights report", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return openapigenerated.RestInsightReport{}, err
+	}
+
+	if response.ApplicationjsonCharsetUTF8200 != nil {
+		return *response.ApplicationjsonCharsetUTF8200, nil
+	}
+
+	return openapigenerated.RestInsightReport{}, nil
+}
+
+func (service *Service) GetReport(ctx context.Context, repo RepositoryRef, commitID string, key string) (openapigenerated.RestInsightReport, error) {
+	if err := validateRepositoryRef(repo); err != nil {
+		return openapigenerated.RestInsightReport{}, err
+	}
+
+	trimmedCommitID := strings.TrimSpace(commitID)
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedCommitID == "" {
+		return openapigenerated.RestInsightReport{}, apperrors.New(apperrors.KindValidation, "commit id is required", nil)
+	}
+	if trimmedKey == "" {
+		return openapigenerated.RestInsightReport{}, apperrors.New(apperrors.KindValidation, "report key is required", nil)
+	}
+
+	response, err := service.client.GetACodeInsightsReportWithResponse(ctx, repo.ProjectKey, repo.Slug, trimmedCommitID, trimmedKey)
+	if err != nil {
+		return openapigenerated.RestInsightReport{}, apperrors.New(apperrors.KindTransient, "failed to get code insights report", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return openapigenerated.RestInsightReport{}, err
+	}
+
+	if response.ApplicationjsonCharsetUTF8200 != nil {
+		return *response.ApplicationjsonCharsetUTF8200, nil
+	}
+
+	return openapigenerated.RestInsightReport{}, nil
+}
+
+func (service *Service) DeleteReport(ctx context.Context, repo RepositoryRef, commitID string, key string) error {
+	if err := validateRepositoryRef(repo); err != nil {
+		return err
+	}
+
+	trimmedCommitID := strings.TrimSpace(commitID)
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedCommitID == "" {
+		return apperrors.New(apperrors.KindValidation, "commit id is required", nil)
+	}
+	if trimmedKey == "" {
+		return apperrors.New(apperrors.KindValidation, "report key is required", nil)
+	}
+
+	response, err := service.client.DeleteACodeInsightsReportWithResponse(ctx, repo.ProjectKey, repo.Slug, trimmedCommitID, trimmedKey)
+	if err != nil {
+		return apperrors.New(apperrors.KindTransient, "failed to delete code insights report", err)
+	}
+
+	return mapStatusError(response.StatusCode(), response.Body)
+}
+
+func (service *Service) AddAnnotations(ctx context.Context, repo RepositoryRef, commitID string, key string, annotations []openapigenerated.RestSingleAddInsightAnnotationRequest) error {
+	if err := validateRepositoryRef(repo); err != nil {
+		return err
+	}
+
+	trimmedCommitID := strings.TrimSpace(commitID)
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedCommitID == "" {
+		return apperrors.New(apperrors.KindValidation, "commit id is required", nil)
+	}
+	if trimmedKey == "" {
+		return apperrors.New(apperrors.KindValidation, "report key is required", nil)
+	}
+	if len(annotations) == 0 {
+		return apperrors.New(apperrors.KindValidation, "at least one annotation is required", nil)
+	}
+
+	body := openapigenerated.AddAnnotationsJSONRequestBody{Annotations: &annotations}
+	response, err := service.client.AddAnnotationsWithResponse(ctx, repo.ProjectKey, repo.Slug, trimmedCommitID, trimmedKey, body)
+	if err != nil {
+		return apperrors.New(apperrors.KindTransient, "failed to add code insights annotations", err)
+	}
+
+	return mapStatusError(response.StatusCode(), response.Body)
+}
+
+func (service *Service) ListAnnotations(ctx context.Context, repo RepositoryRef, commitID string, key string) ([]openapigenerated.RestInsightAnnotation, error) {
+	if err := validateRepositoryRef(repo); err != nil {
+		return nil, err
+	}
+
+	trimmedCommitID := strings.TrimSpace(commitID)
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedCommitID == "" {
+		return nil, apperrors.New(apperrors.KindValidation, "commit id is required", nil)
+	}
+	if trimmedKey == "" {
+		return nil, apperrors.New(apperrors.KindValidation, "report key is required", nil)
+	}
+
+	response, err := service.client.GetAnnotationsWithResponse(ctx, repo.ProjectKey, repo.Slug, trimmedCommitID, trimmedKey)
+	if err != nil {
+		return nil, apperrors.New(apperrors.KindTransient, "failed to list code insights annotations", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return nil, err
+	}
+	if response.ApplicationjsonCharsetUTF8200 == nil || response.ApplicationjsonCharsetUTF8200.Annotations == nil {
+		return []openapigenerated.RestInsightAnnotation{}, nil
+	}
+
+	return *response.ApplicationjsonCharsetUTF8200.Annotations, nil
+}
+
+func (service *Service) DeleteAnnotations(ctx context.Context, repo RepositoryRef, commitID string, key string, externalID string) error {
+	if err := validateRepositoryRef(repo); err != nil {
+		return err
+	}
+
+	trimmedCommitID := strings.TrimSpace(commitID)
+	trimmedKey := strings.TrimSpace(key)
+	trimmedExternalID := strings.TrimSpace(externalID)
+	if trimmedCommitID == "" {
+		return apperrors.New(apperrors.KindValidation, "commit id is required", nil)
+	}
+	if trimmedKey == "" {
+		return apperrors.New(apperrors.KindValidation, "report key is required", nil)
+	}
+	if trimmedExternalID == "" {
+		return apperrors.New(apperrors.KindValidation, "external annotation id is required", nil)
+	}
+
+	response, err := service.client.DeleteAnnotationsWithResponse(
+		ctx,
+		repo.ProjectKey,
+		repo.Slug,
+		trimmedCommitID,
+		trimmedKey,
+		&openapigenerated.DeleteAnnotationsParams{ExternalId: &trimmedExternalID},
+	)
+	if err != nil {
+		return apperrors.New(apperrors.KindTransient, "failed to delete code insights annotations", err)
+	}
+
+	return mapStatusError(response.StatusCode(), response.Body)
+}
+
+func validateRepositoryRef(repo RepositoryRef) error {
+	if strings.TrimSpace(repo.ProjectKey) == "" || strings.TrimSpace(repo.Slug) == "" {
+		return apperrors.New(apperrors.KindValidation, "repository must be specified as project/repo", nil)
+	}
+
+	return nil
+}
+
+func mapStatusError(status int, body []byte) error {
+	if status >= 200 && status < 300 {
+		return nil
+	}
+
+	message := strings.TrimSpace(string(body))
+	if message == "" {
+		message = http.StatusText(status)
+	}
+
+	baseMessage := fmt.Sprintf("bitbucket API returned %d: %s", status, message)
+
+	switch status {
+	case http.StatusBadRequest:
+		return apperrors.New(apperrors.KindValidation, baseMessage, nil)
+	case http.StatusUnauthorized:
+		return apperrors.New(apperrors.KindAuthentication, baseMessage, nil)
+	case http.StatusForbidden:
+		return apperrors.New(apperrors.KindAuthorization, baseMessage, nil)
+	case http.StatusNotFound:
+		return apperrors.New(apperrors.KindNotFound, baseMessage, nil)
+	case http.StatusConflict:
+		return apperrors.New(apperrors.KindConflict, baseMessage, nil)
+	case http.StatusTooManyRequests:
+		return apperrors.New(apperrors.KindTransient, baseMessage, nil)
+	default:
+		if status >= 500 {
+			return apperrors.New(apperrors.KindTransient, baseMessage, nil)
+		}
+		return apperrors.New(apperrors.KindPermanent, baseMessage, nil)
+	}
+}

--- a/internal/services/tag/service.go
+++ b/internal/services/tag/service.go
@@ -1,0 +1,202 @@
+package tag
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
+	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
+)
+
+type RepositoryRef struct {
+	ProjectKey string
+	Slug       string
+}
+
+type ListOptions struct {
+	Limit      int
+	OrderBy    string
+	FilterText string
+}
+
+type Service struct {
+	client *openapigenerated.ClientWithResponses
+}
+
+func NewService(client *openapigenerated.ClientWithResponses) *Service {
+	return &Service{client: client}
+}
+
+func (service *Service) List(ctx context.Context, repo RepositoryRef, options ListOptions) ([]openapigenerated.RestTag, error) {
+	if err := validateRepositoryRef(repo); err != nil {
+		return nil, err
+	}
+
+	if options.Limit <= 0 {
+		options.Limit = 25
+	}
+
+	start := float32(0)
+	pageLimit := float32(options.Limit)
+	results := make([]openapigenerated.RestTag, 0)
+
+	for {
+		params := &openapigenerated.GetTagsParams{Start: &start, Limit: &pageLimit}
+		if strings.TrimSpace(options.OrderBy) != "" {
+			orderBy := strings.TrimSpace(options.OrderBy)
+			params.OrderBy = &orderBy
+		}
+		if strings.TrimSpace(options.FilterText) != "" {
+			filterText := strings.TrimSpace(options.FilterText)
+			params.FilterText = &filterText
+		}
+
+		response, err := service.client.GetTagsWithResponse(ctx, repo.ProjectKey, repo.Slug, params)
+		if err != nil {
+			return nil, apperrors.New(apperrors.KindTransient, "failed to list repository tags", err)
+		}
+		if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+			return nil, err
+		}
+		if response.ApplicationjsonCharsetUTF8200 == nil || response.ApplicationjsonCharsetUTF8200.Values == nil {
+			break
+		}
+
+		results = append(results, (*response.ApplicationjsonCharsetUTF8200.Values)...)
+
+		if response.ApplicationjsonCharsetUTF8200.IsLastPage != nil && *response.ApplicationjsonCharsetUTF8200.IsLastPage {
+			break
+		}
+		if response.ApplicationjsonCharsetUTF8200.NextPageStart == nil {
+			break
+		}
+
+		start = float32(*response.ApplicationjsonCharsetUTF8200.NextPageStart)
+	}
+
+	return results, nil
+}
+
+func (service *Service) Create(ctx context.Context, repo RepositoryRef, name string, startPoint string, message string) (openapigenerated.RestTag, error) {
+	if err := validateRepositoryRef(repo); err != nil {
+		return openapigenerated.RestTag{}, err
+	}
+
+	trimmedName := strings.TrimSpace(name)
+	trimmedStartPoint := strings.TrimSpace(startPoint)
+	if trimmedName == "" {
+		return openapigenerated.RestTag{}, apperrors.New(apperrors.KindValidation, "tag name is required", nil)
+	}
+	if trimmedStartPoint == "" {
+		return openapigenerated.RestTag{}, apperrors.New(apperrors.KindValidation, "tag start-point is required", nil)
+	}
+
+	body := openapigenerated.CreateTagForRepositoryJSONRequestBody{
+		Name:       &trimmedName,
+		StartPoint: &trimmedStartPoint,
+	}
+	if strings.TrimSpace(message) != "" {
+		trimmedMessage := strings.TrimSpace(message)
+		body.Message = &trimmedMessage
+	}
+
+	response, err := service.client.CreateTagForRepositoryWithResponse(ctx, repo.ProjectKey, repo.Slug, body)
+	if err != nil {
+		return openapigenerated.RestTag{}, apperrors.New(apperrors.KindTransient, "failed to create repository tag", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return openapigenerated.RestTag{}, err
+	}
+
+	if response.ApplicationjsonCharsetUTF8200 != nil {
+		return *response.ApplicationjsonCharsetUTF8200, nil
+	}
+
+	return openapigenerated.RestTag{}, nil
+}
+
+func (service *Service) Get(ctx context.Context, repo RepositoryRef, name string) (openapigenerated.RestTag, error) {
+	if err := validateRepositoryRef(repo); err != nil {
+		return openapigenerated.RestTag{}, err
+	}
+
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		return openapigenerated.RestTag{}, apperrors.New(apperrors.KindValidation, "tag name is required", nil)
+	}
+
+	response, err := service.client.GetTagWithResponse(ctx, repo.ProjectKey, repo.Slug, trimmedName)
+	if err != nil {
+		return openapigenerated.RestTag{}, apperrors.New(apperrors.KindTransient, "failed to get repository tag", err)
+	}
+	if err := mapStatusError(response.StatusCode(), response.Body); err != nil {
+		return openapigenerated.RestTag{}, err
+	}
+
+	if response.ApplicationjsonCharsetUTF8200 != nil {
+		return *response.ApplicationjsonCharsetUTF8200, nil
+	}
+
+	return openapigenerated.RestTag{}, nil
+}
+
+func (service *Service) Delete(ctx context.Context, repo RepositoryRef, name string) error {
+	if err := validateRepositoryRef(repo); err != nil {
+		return err
+	}
+
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		return apperrors.New(apperrors.KindValidation, "tag name is required", nil)
+	}
+
+	response, err := service.client.DeleteTagWithResponse(ctx, repo.ProjectKey, repo.Slug, trimmedName)
+	if err != nil {
+		return apperrors.New(apperrors.KindTransient, "failed to delete repository tag", err)
+	}
+
+	return mapStatusError(response.StatusCode(), response.Body)
+}
+
+func validateRepositoryRef(repo RepositoryRef) error {
+	if strings.TrimSpace(repo.ProjectKey) == "" || strings.TrimSpace(repo.Slug) == "" {
+		return apperrors.New(apperrors.KindValidation, "repository must be specified as project/repo", nil)
+	}
+
+	return nil
+}
+
+func mapStatusError(status int, body []byte) error {
+	if status >= 200 && status < 300 {
+		return nil
+	}
+
+	message := strings.TrimSpace(string(body))
+	if message == "" {
+		message = http.StatusText(status)
+	}
+
+	baseMessage := fmt.Sprintf("bitbucket API returned %d: %s", status, message)
+
+	switch status {
+	case http.StatusBadRequest:
+		return apperrors.New(apperrors.KindValidation, baseMessage, nil)
+	case http.StatusUnauthorized:
+		return apperrors.New(apperrors.KindAuthentication, baseMessage, nil)
+	case http.StatusForbidden:
+		return apperrors.New(apperrors.KindAuthorization, baseMessage, nil)
+	case http.StatusNotFound:
+		return apperrors.New(apperrors.KindNotFound, baseMessage, nil)
+	case http.StatusConflict:
+		return apperrors.New(apperrors.KindConflict, baseMessage, nil)
+	case http.StatusTooManyRequests:
+		return apperrors.New(apperrors.KindTransient, baseMessage, nil)
+	default:
+		if status >= 500 {
+			return apperrors.New(apperrors.KindTransient, baseMessage, nil)
+		}
+		return apperrors.New(apperrors.KindPermanent, baseMessage, nil)
+	}
+}

--- a/tests/integration/live/quality_live_test.go
+++ b/tests/integration/live/quality_live_test.go
@@ -1,0 +1,115 @@
+//go:build live
+
+package live_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
+	qualityservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/quality"
+)
+
+func TestLiveBuildStatusSetAndGet(t *testing.T) {
+	harness := newLiveHarness(t)
+	service := qualityservice.NewService(harness.client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	seeded, err := harness.seedProjectWithRepositories(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("seed project with repositories failed: %v", err)
+	}
+
+	repo := seeded.Repos[0]
+	commitID := repo.CommitIDs[0]
+	buildKey := fmt.Sprintf("live-build-%d", time.Now().UnixNano()%100000)
+
+	err = service.SetBuildStatus(ctx, commitID, qualityservice.BuildStatusSetInput{
+		Key:   buildKey,
+		State: "SUCCESSFUL",
+		URL:   "https://example.invalid/live-build",
+		Name:  "Live Build",
+	})
+	if err != nil {
+		t.Fatalf("set build status failed: %v", err)
+	}
+
+	statuses, err := service.GetBuildStatuses(ctx, commitID, 25, "NEWEST")
+	if err != nil {
+		t.Fatalf("get build statuses failed: %v", err)
+	}
+
+	found := false
+	for _, status := range statuses {
+		if status.Key != nil && *status.Key == buildKey {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected build status key=%s in response", buildKey)
+	}
+}
+
+func TestLiveCodeInsightsReportSetAndGet(t *testing.T) {
+	harness := newLiveHarness(t)
+	service := qualityservice.NewService(harness.client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	seeded, err := harness.seedProjectWithRepositories(ctx, 1, 1)
+	if err != nil {
+		t.Fatalf("seed project with repositories failed: %v", err)
+	}
+
+	repo := seeded.Repos[0]
+	commitID := repo.CommitIDs[0]
+	reportKey := fmt.Sprintf("live-report-%d", time.Now().UnixNano()%100000)
+	title := "Live Insights"
+	result := "PASS"
+	dataTitle := "coverage"
+	dataType := "NUMBER"
+	value := map[string]any{"value": 100}
+
+	reportRequest := openapigenerated.SetACodeInsightsReportJSONRequestBody{
+		Title:  title,
+		Result: &result,
+		Data: []openapigenerated.RestInsightReportData{
+			{Title: &dataTitle, Type: &dataType, Value: &value},
+		},
+	}
+
+	_, err = service.SetReport(
+		ctx,
+		qualityservice.RepositoryRef{ProjectKey: seeded.Key, Slug: repo.Slug},
+		commitID,
+		reportKey,
+		reportRequest,
+	)
+	if err != nil {
+		t.Fatalf("set report failed: %v", err)
+	}
+
+	report, err := service.GetReport(
+		ctx,
+		qualityservice.RepositoryRef{ProjectKey: seeded.Key, Slug: repo.Slug},
+		commitID,
+		reportKey,
+	)
+	if err != nil {
+		t.Fatalf("get report failed: %v", err)
+	}
+
+	if report.Key == nil || *report.Key != reportKey {
+		t.Fatalf("expected report key=%s, got %#v", reportKey, report.Key)
+	}
+	if report.Title == nil || *report.Title != title {
+		t.Fatalf("expected report title=%s, got %#v", title, report.Title)
+	}
+}

--- a/tests/integration/live/tag_live_test.go
+++ b/tests/integration/live/tag_live_test.go
@@ -1,0 +1,65 @@
+//go:build live
+
+package live_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
+	tagservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/tag"
+)
+
+func TestLiveTagLifecycle(t *testing.T) {
+	harness := newLiveHarness(t)
+	service := tagservice.NewService(harness.client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	seeded, err := harness.seedProjectWithRepositories(ctx, 1, 2)
+	if err != nil {
+		t.Fatalf("seed project with repositories failed: %v", err)
+	}
+
+	repo := seeded.Repos[0]
+	tagName := fmt.Sprintf("v-live-%d", time.Now().UnixNano()%100000)
+
+	created, err := service.Create(
+		ctx,
+		tagservice.RepositoryRef{ProjectKey: seeded.Key, Slug: repo.Slug},
+		tagName,
+		repo.CommitIDs[0],
+		"live test tag",
+	)
+	if err != nil {
+		t.Fatalf("create tag failed: %v", err)
+	}
+	if created.DisplayId == nil || *created.DisplayId == "" {
+		t.Fatalf("created tag display id missing: %#v", created)
+	}
+
+	fetched, err := service.Get(ctx, tagservice.RepositoryRef{ProjectKey: seeded.Key, Slug: repo.Slug}, tagName)
+	if err != nil {
+		t.Fatalf("get tag failed: %v", err)
+	}
+	if fetched.DisplayId == nil || *fetched.DisplayId != tagName {
+		t.Fatalf("expected fetched tag=%s, got %#v", tagName, fetched.DisplayId)
+	}
+
+	if err := service.Delete(ctx, tagservice.RepositoryRef{ProjectKey: seeded.Key, Slug: repo.Slug}, tagName); err != nil {
+		t.Fatalf("delete tag failed: %v", err)
+	}
+
+	_, err = service.Get(ctx, tagservice.RepositoryRef{ProjectKey: seeded.Key, Slug: repo.Slug}, tagName)
+	if err == nil {
+		t.Fatalf("expected not found error after tag delete")
+	}
+
+	appErr, ok := err.(*errors.AppError)
+	if !ok || appErr.Kind != errors.KindNotFound {
+		t.Fatalf("expected not_found error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Implements #4 and #5 end-to-end
- Adds CLI groups: `tag`, `build status`, `build required`, `insights report`, `insights annotation`
- Adds service layers in `internal/services/tag/service.go` and `internal/services/quality/service.go`
- Adds live integration tests for tag lifecycle and build/insights flows
- Updates command examples in `README.md`

## Validation
- `go test ./internal/cli ./internal/services/tag ./internal/services/quality`

Closes #4
Closes #5