### PR TITLE
feat: implement pr list and remove issue placeholder command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Common commands:
 Coverage/reporting workflow:
 
 - combined metric source is unit + live coverage merged into one report
+- pre-commit hook gate: `task quality:coverage:origin-main` (runs live tests and enforces combined patch coverage >= 85% vs `origin/main`)
 - local report update (commit this artifact): `task quality:coverage:report:update`
 - local pre-push verification (recompute + compare): `task quality:coverage:report:verify`
 - CI verification (committed artifact only): `task quality:coverage:report:verify:committed`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,6 +70,14 @@ tasks:
       - task: test:live:coverage
       - go run ./tools/quality-report -coverprofile .tmp/coverage.unit.out -live-coverprofile .tmp/coverage.live.out -base-ref {{.COVERAGE_BASE_REF}} -manifest docs/quality/generated-operation-contracts.json -min-scoped {{.COVERAGE_MIN_SCOPED}} -min-patch {{.COVERAGE_MIN_PATCH}} -min-contract {{.COVERAGE_MIN_CONTRACT}}
 
+  quality:coverage:origin-main:
+    desc: Run combined (unit + live) patch coverage gate against origin/main (requires live infra)
+    cmds:
+      - git fetch origin main
+      - task: test:unit:coverage
+      - task: test:live:coverage
+      - go run ./tools/quality-report -coverprofile .tmp/coverage.unit.out -live-coverprofile .tmp/coverage.live.out -base-ref origin/main -manifest docs/quality/generated-operation-contracts.json -min-scoped {{.COVERAGE_MIN_SCOPED}} -min-patch {{.COVERAGE_MIN_PATCH}} -min-contract {{.COVERAGE_MIN_CONTRACT}}
+
   quality:coverage:report:update:
     desc: Update committed combined coverage report artifact
     cmds:

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -15,6 +15,7 @@ import (
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
 	commentservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/comment"
 	diffservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/diff"
+	pullrequestservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/pullrequest"
 	qualityservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/quality"
 	reposettings "github.com/vriesdemichael/bitbucket-server-cli/internal/services/reposettings"
 	"github.com/vriesdemichael/bitbucket-server-cli/internal/services/repository"
@@ -41,7 +42,6 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.AddCommand(newBuildCommand(options))
 	rootCmd.AddCommand(newInsightsCommand(options))
 	rootCmd.AddCommand(newPRCommand(options))
-	rootCmd.AddCommand(newIssueCommand(options))
 	rootCmd.AddCommand(newAdminCommand(options))
 
 	return rootCmd
@@ -1522,18 +1522,80 @@ func newInsightsCommand(options *rootOptions) *cobra.Command {
 }
 
 func newPRCommand(options *rootOptions) *cobra.Command {
+	var repository string
+	var state string
+	var limit int
+	var start int
+	var sourceBranch string
+	var targetBranch string
+
 	prCmd := &cobra.Command{
 		Use:   "pr",
 		Short: "Pull request commands",
 	}
 
-	prCmd.AddCommand(&cobra.Command{
+	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List pull requests",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return apperrors.New(apperrors.KindNotImplemented, "pr list is not implemented yet", nil)
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+
+			repo, err := resolvePullRequestRepositoryReference(repository, cfg)
+			if err != nil {
+				return err
+			}
+
+			service := pullrequestservice.NewService(httpclient.NewFromConfig(cfg))
+			pullRequests, err := service.List(cmd.Context(), repo, pullrequestservice.ListOptions{
+				State:        state,
+				Limit:        limit,
+				Start:        start,
+				SourceBranch: sourceBranch,
+				TargetBranch: targetBranch,
+			})
+			if err != nil {
+				return err
+			}
+
+			if options.JSON {
+				return writeJSON(cmd.OutOrStdout(), map[string]any{
+					"repository":    repo,
+					"filters":       map[string]any{"state": strings.ToLower(strings.TrimSpace(state)), "start": start, "limit": limit, "source_branch": sourceBranch, "target_branch": targetBranch},
+					"pull_requests": pullRequests,
+				})
+			}
+
+			if len(pullRequests) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No pull requests found")
+				return nil
+			}
+
+			for _, pullRequest := range pullRequests {
+				fmt.Fprintf(
+					cmd.OutOrStdout(),
+					"#%d\t%s\t%s -> %s\t%s\n",
+					pullRequest.ID,
+					pullRequest.State,
+					pullRequest.SourceBranch,
+					pullRequest.TargetBranch,
+					pullRequest.Title,
+				)
+			}
+
+			return nil
 		},
-	})
+	}
+
+	listCmd.Flags().StringVar(&repository, "repo", "", "Repository as PROJECT/slug (defaults to BITBUCKET_PROJECT_KEY + BITBUCKET_REPO_SLUG)")
+	listCmd.Flags().StringVar(&state, "state", "open", "Pull request state filter: open, closed, all")
+	listCmd.Flags().IntVar(&limit, "limit", 25, "Page size for Bitbucket pull request list operations")
+	listCmd.Flags().IntVar(&start, "start", 0, "Start offset for Bitbucket pull request list operations")
+	listCmd.Flags().StringVar(&sourceBranch, "source-branch", "", "Optional source branch filter")
+	listCmd.Flags().StringVar(&targetBranch, "target-branch", "", "Optional target branch filter")
+	prCmd.AddCommand(listCmd)
 
 	return prCmd
 }
@@ -1582,6 +1644,15 @@ func resolveRepositorySettingsReference(selector string, cfg config.AppConfig) (
 	}
 
 	return reposettings.RepositoryRef{ProjectKey: repo.ProjectKey, Slug: repo.Slug}, nil
+}
+
+func resolvePullRequestRepositoryReference(selector string, cfg config.AppConfig) (pullrequestservice.RepositoryRef, error) {
+	repo, err := resolveRepositorySelector(selector, cfg)
+	if err != nil {
+		return pullrequestservice.RepositoryRef{}, err
+	}
+
+	return pullrequestservice.RepositoryRef{ProjectKey: repo.ProjectKey, Slug: repo.Slug}, nil
 }
 
 func resolveTagRepositoryReference(selector string, cfg config.AppConfig) (tagservice.RepositoryRef, error) {
@@ -1704,23 +1775,6 @@ func formatCommentSummary(comment openapigenerated.RestComment) string {
 	}
 
 	return fmt.Sprintf("[%s v%s] %s", commentIDString(comment), version, text)
-}
-
-func newIssueCommand(options *rootOptions) *cobra.Command {
-	issueCmd := &cobra.Command{
-		Use:   "issue",
-		Short: "Issue commands",
-	}
-
-	issueCmd.AddCommand(&cobra.Command{
-		Use:   "list",
-		Short: "List issues",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return apperrors.New(apperrors.KindNotImplemented, "issue list is not implemented yet", nil)
-		},
-	})
-
-	return issueCmd
 }
 
 func newAdminCommand(options *rootOptions) *cobra.Command {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 
 	"github.com/vriesdemichael/bitbucket-server-cli/internal/config"
-	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
 	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
+	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
 	"github.com/vriesdemichael/bitbucket-server-cli/internal/services/diff"
 )
 
@@ -793,33 +793,54 @@ func TestAdminHealthPropagatesHardFailure(t *testing.T) {
 	}
 }
 
-func TestPRAndIssueListNotImplemented(t *testing.T) {
+func TestPRListAndIssueCommandUnavailable(t *testing.T) {
 	t.Setenv("BBSC_DISABLE_STORED_CONFIG", "1")
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet || request.URL.Path != "/rest/api/latest/projects/TEST/repos/demo/pull-requests" {
+			http.NotFound(writer, request)
+			return
+		}
 
-	tests := []struct {
-		name string
-		args []string
-	}{
-		{name: "pr", args: []string{"pr", "list"}},
-		{name: "issue", args: []string{"issue", "list"}},
+		if request.URL.Query().Get("state") != "OPEN" {
+			writer.WriteHeader(http.StatusBadRequest)
+			_, _ = writer.Write([]byte("unexpected state query"))
+			return
+		}
+
+		writer.Header().Set("Content-Type", "application/json;charset=UTF-8")
+		_, _ = writer.Write([]byte(`{"isLastPage":true,"nextPageStart":0,"values":[{"id":22,"title":"Feature PR","state":"OPEN","open":true,"closed":false,"fromRef":{"displayId":"feature/demo"},"toRef":{"displayId":"master"}}]}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("BITBUCKET_URL", server.URL)
+	t.Setenv("BITBUCKET_PROJECT_KEY", "TEST")
+	t.Setenv("BITBUCKET_REPO_SLUG", "demo")
+
+	prCommand := NewRootCommand()
+	prOutput := &bytes.Buffer{}
+	prCommand.SetOut(prOutput)
+	prCommand.SetErr(prOutput)
+	prCommand.SetArgs([]string{"pr", "list", "--state", "open", "--limit", "10"})
+
+	if err := prCommand.Execute(); err != nil {
+		t.Fatalf("expected pr list to succeed, got: %v", err)
+	}
+	if !strings.Contains(prOutput.String(), "#22") || !strings.Contains(prOutput.String(), "feature/demo -> master") {
+		t.Fatalf("expected pull request in human output, got: %s", prOutput.String())
 	}
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			command := NewRootCommand()
-			command.SetOut(&bytes.Buffer{})
-			command.SetErr(&bytes.Buffer{})
-			command.SetArgs(testCase.args)
+	issueCommand := NewRootCommand()
+	issueOutput := &bytes.Buffer{}
+	issueCommand.SetOut(issueOutput)
+	issueCommand.SetErr(issueOutput)
+	issueCommand.SetArgs([]string{"issue", "list"})
 
-			err := command.Execute()
-			if err == nil {
-				t.Fatal("expected not implemented error")
-			}
-
-			if apperrors.ExitCode(err) != 11 {
-				t.Fatalf("expected not implemented exit code 11, got: %d", apperrors.ExitCode(err))
-			}
-		})
+	err := issueCommand.Execute()
+	if err == nil {
+		t.Fatal("expected issue command to be unavailable")
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Fatalf("expected unknown command error, got: %v", err)
 	}
 }
 

--- a/internal/services/pullrequest/service.go
+++ b/internal/services/pullrequest/service.go
@@ -1,0 +1,222 @@
+package pullrequest
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
+)
+
+type RepositoryRef struct {
+	ProjectKey string `json:"project_key"`
+	Slug       string `json:"slug"`
+}
+
+type ListOptions struct {
+	State        string `json:"state"`
+	Limit        int    `json:"limit"`
+	Start        int    `json:"start"`
+	SourceBranch string `json:"source_branch,omitempty"`
+	TargetBranch string `json:"target_branch,omitempty"`
+}
+
+type PullRequest struct {
+	ID           int64  `json:"id"`
+	Title        string `json:"title"`
+	State        string `json:"state"`
+	Open         bool   `json:"open"`
+	Closed       bool   `json:"closed"`
+	Author       string `json:"author,omitempty"`
+	SourceBranch string `json:"source_branch,omitempty"`
+	TargetBranch string `json:"target_branch,omitempty"`
+	CreatedDate  int64  `json:"created_date,omitempty"`
+	UpdatedDate  int64  `json:"updated_date,omitempty"`
+}
+
+type Service struct {
+	client *httpclient.Client
+}
+
+func NewService(client *httpclient.Client) *Service {
+	return &Service{client: client}
+}
+
+func (service *Service) List(ctx context.Context, repository RepositoryRef, options ListOptions) ([]PullRequest, error) {
+	if strings.TrimSpace(repository.ProjectKey) == "" || strings.TrimSpace(repository.Slug) == "" {
+		return nil, apperrors.New(apperrors.KindValidation, "repository must be specified as project/repo", nil)
+	}
+
+	normalizedState, err := normalizeState(options.State)
+	if err != nil {
+		return nil, err
+	}
+
+	if options.Limit <= 0 {
+		options.Limit = 25
+	}
+	if options.Start < 0 {
+		return nil, apperrors.New(apperrors.KindValidation, "start must be greater than or equal to 0", nil)
+	}
+
+	path := fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/pull-requests", repository.ProjectKey, repository.Slug)
+	results := make([]PullRequest, 0)
+	start := options.Start
+
+	for {
+		query := map[string]string{
+			"limit": strconv.Itoa(options.Limit),
+			"start": strconv.Itoa(start),
+		}
+		if normalizedState == "open" {
+			query["state"] = "OPEN"
+		} else {
+			query["state"] = "ALL"
+		}
+
+		var response pagedPullRequestResponse
+		if err := service.client.GetJSON(ctx, path, query, &response); err != nil {
+			return nil, err
+		}
+
+		for _, value := range response.Values {
+			mapped := mapPullRequest(value)
+			if matchesFilters(mapped, normalizedState, options.SourceBranch, options.TargetBranch) {
+				results = append(results, mapped)
+			}
+		}
+
+		if response.IsLastPage {
+			break
+		}
+
+		if response.NextPageStart == start {
+			break
+		}
+
+		start = response.NextPageStart
+	}
+
+	return results, nil
+}
+
+func normalizeState(state string) (string, error) {
+	resolved := strings.ToLower(strings.TrimSpace(state))
+	if resolved == "" {
+		return "open", nil
+	}
+
+	switch resolved {
+	case "open", "closed", "all":
+		return resolved, nil
+	default:
+		return "", apperrors.New(apperrors.KindValidation, "--state must be one of: open, closed, all", nil)
+	}
+}
+
+func matchesFilters(pullRequest PullRequest, state string, sourceBranch string, targetBranch string) bool {
+	switch state {
+	case "open":
+		if !pullRequest.Open {
+			return false
+		}
+	case "closed":
+		if pullRequest.Open && !pullRequest.Closed {
+			return false
+		}
+	}
+
+	if !branchMatches(sourceBranch, pullRequest.SourceBranch) {
+		return false
+	}
+
+	if !branchMatches(targetBranch, pullRequest.TargetBranch) {
+		return false
+	}
+
+	return true
+}
+
+func branchMatches(filter string, actual string) bool {
+	trimmedFilter := strings.TrimSpace(filter)
+	if trimmedFilter == "" {
+		return true
+	}
+
+	return normalizeBranch(trimmedFilter) == normalizeBranch(actual)
+}
+
+func normalizeBranch(branch string) string {
+	trimmed := strings.TrimSpace(branch)
+	trimmed = strings.TrimPrefix(trimmed, "refs/heads/")
+	return strings.ToLower(trimmed)
+}
+
+func mapPullRequest(raw pullRequestValue) PullRequest {
+	author := ""
+	if raw.Author != nil && raw.Author.User != nil {
+		author = strings.TrimSpace(raw.Author.User.DisplayName)
+		if author == "" {
+			author = strings.TrimSpace(raw.Author.User.Name)
+		}
+	}
+
+	return PullRequest{
+		ID:           raw.ID,
+		Title:        raw.Title,
+		State:        strings.TrimSpace(raw.State),
+		Open:         raw.Open,
+		Closed:       raw.Closed,
+		Author:       author,
+		SourceBranch: branchDisplayName(raw.FromRef),
+		TargetBranch: branchDisplayName(raw.ToRef),
+		CreatedDate:  raw.CreatedDate,
+		UpdatedDate:  raw.UpdatedDate,
+	}
+}
+
+func branchDisplayName(reference *pullRequestRef) string {
+	if reference == nil {
+		return ""
+	}
+
+	display := strings.TrimSpace(reference.DisplayID)
+	if display != "" {
+		return display
+	}
+
+	return strings.TrimSpace(reference.ID)
+}
+
+type pagedPullRequestResponse struct {
+	Values        []pullRequestValue `json:"values"`
+	IsLastPage    bool               `json:"isLastPage"`
+	NextPageStart int                `json:"nextPageStart"`
+}
+
+type pullRequestValue struct {
+	ID          int64            `json:"id"`
+	Title       string           `json:"title"`
+	State       string           `json:"state"`
+	Open        bool             `json:"open"`
+	Closed      bool             `json:"closed"`
+	CreatedDate int64            `json:"createdDate"`
+	UpdatedDate int64            `json:"updatedDate"`
+	Author      *pullRequestUser `json:"author"`
+	FromRef     *pullRequestRef  `json:"fromRef"`
+	ToRef       *pullRequestRef  `json:"toRef"`
+}
+
+type pullRequestUser struct {
+	User *struct {
+		Name        string `json:"name"`
+		DisplayName string `json:"displayName"`
+	} `json:"user"`
+}
+
+type pullRequestRef struct {
+	ID        string `json:"id"`
+	DisplayID string `json:"displayId"`
+}

--- a/internal/services/pullrequest/service_test.go
+++ b/internal/services/pullrequest/service_test.go
@@ -1,0 +1,113 @@
+package pullrequest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/config"
+	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
+)
+
+func TestListPullRequestsWithPaginationAndFilters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/rest/api/latest/projects/TEST/repos/demo/pull-requests" {
+			http.NotFound(w, request)
+			return
+		}
+
+		start := request.URL.Query().Get("start")
+		if start == "" || start == "0" {
+			_, _ = fmt.Fprint(w, `{"values":[{"id":1,"title":"Open PR","state":"OPEN","open":true,"closed":false,"fromRef":{"displayId":"feature/a"},"toRef":{"displayId":"master"},"author":{"user":{"displayName":"A"}}}],"isLastPage":false,"nextPageStart":1}`)
+			return
+		}
+
+		_, _ = fmt.Fprint(w, `{"values":[{"id":2,"title":"Merged PR","state":"MERGED","open":false,"closed":true,"fromRef":{"displayId":"feature/b"},"toRef":{"displayId":"master"},"author":{"user":{"name":"b-user"}}}],"isLastPage":true,"nextPageStart":2}`)
+	}))
+	defer server.Close()
+
+	t.Setenv("BITBUCKET_URL", server.URL)
+	t.Setenv("BITBUCKET_PROJECT_KEY", "TEST")
+
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	service := NewService(httpclient.NewFromConfig(cfg))
+
+	results, err := service.List(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, ListOptions{State: "all", Limit: 1, SourceBranch: "feature/b"})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 filtered pull request, got %d", len(results))
+	}
+	if results[0].ID != 2 || results[0].Author != "b-user" {
+		t.Fatalf("unexpected mapped pull request: %#v", results[0])
+	}
+}
+
+func TestListPullRequestsValidationAndAuthError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, `{"errors":[{"message":"Authentication required"}]}`)
+	}))
+	defer server.Close()
+
+	t.Setenv("BITBUCKET_URL", server.URL)
+	t.Setenv("BITBUCKET_PROJECT_KEY", "TEST")
+
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	service := NewService(httpclient.NewFromConfig(cfg))
+
+	_, err = service.List(context.Background(), RepositoryRef{}, ListOptions{})
+	if err == nil || apperrors.ExitCode(err) != 2 {
+		t.Fatalf("expected validation error exit code 2, got: %v", err)
+	}
+
+	_, err = service.List(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, ListOptions{State: "invalid"})
+	if err == nil || apperrors.ExitCode(err) != 2 {
+		t.Fatalf("expected state validation error exit code 2, got: %v", err)
+	}
+
+	_, err = service.List(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, ListOptions{State: "open", Start: -1})
+	if err == nil || apperrors.ExitCode(err) != 2 {
+		t.Fatalf("expected start validation error exit code 2, got: %v", err)
+	}
+
+	_, err = service.List(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, ListOptions{State: "open", Limit: 5})
+	if err == nil || apperrors.ExitCode(err) != 3 {
+		t.Fatalf("expected auth error exit code 3, got: %v", err)
+	}
+}
+
+func TestPullRequestHelperBranches(t *testing.T) {
+	if normalized, err := normalizeState(""); err != nil || normalized != "open" {
+		t.Fatalf("expected empty state to normalize to open, got=%q err=%v", normalized, err)
+	}
+
+	closedPR := PullRequest{Open: false, Closed: true, SourceBranch: "feature/a", TargetBranch: "master"}
+	if !matchesFilters(closedPR, "closed", "refs/heads/feature/a", "master") {
+		t.Fatal("expected closed pull request to match closed-state and normalized branch filters")
+	}
+
+	openPR := PullRequest{Open: true, Closed: false, SourceBranch: "feature/a", TargetBranch: "master"}
+	if matchesFilters(openPR, "closed", "", "") {
+		t.Fatal("expected open pull request to be excluded by closed-state filter")
+	}
+
+	if branchDisplayName(nil) != "" {
+		t.Fatal("expected empty branch display for nil ref")
+	}
+	if branchDisplayName(&pullRequestRef{ID: "refs/heads/fallback"}) != "refs/heads/fallback" {
+		t.Fatal("expected branch display to fall back to ref id when display id is missing")
+	}
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,9 @@
+pre-commit:
+  parallel: false
+  commands:
+    combined-patch-coverage-gate:
+      run: task quality:coverage:origin-main
+
 pre-push:
   parallel: false
   commands:

--- a/tests/integration/live/cli_command_coverage_live_test.go
+++ b/tests/integration/live/cli_command_coverage_live_test.go
@@ -429,23 +429,59 @@ func TestLiveCLIAuthStoredConfigFlow(t *testing.T) {
 	}
 }
 
-func TestLiveCLIPRAndIssueNotImplemented(t *testing.T) {
-	t.Setenv("BBSC_DISABLE_STORED_CONFIG", "1")
+func TestLiveCLIPRListAndIssueCommandUnavailable(t *testing.T) {
+	harness := newLiveHarness(t)
 
-	prOutput, prErr := executeLiveCLI(t, "pr", "list")
-	if prErr == nil {
-		t.Fatalf("expected pr list to be not implemented")
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	seeded, err := harness.seedProjectWithRepositories(ctx, 1, 1)
+	if err != nil {
+		t.Fatalf("seed project with repositories failed: %v", err)
 	}
-	if !strings.Contains(prOutput, "not implemented") && !strings.Contains(prErr.Error(), "not implemented") {
-		t.Fatalf("expected not implemented message for pr list, output=%s err=%v", prOutput, prErr)
+
+	repo := seeded.Repos[0]
+	configureLiveCLIEnv(t, harness, seeded.Key, repo.Slug)
+
+	branch := fmt.Sprintf("lt-pr-list-%d", time.Now().UnixNano()%100000)
+	if err := harness.pushCommitOnBranch(seeded.Key, repo.Slug, branch, "pr-list-feature.txt"); err != nil {
+		t.Fatalf("push commit on branch failed: %v", err)
+	}
+
+	if _, err := harness.createPullRequest(ctx, seeded.Key, repo.Slug, branch, "master"); err != nil {
+		t.Fatalf("create pull request failed: %v", err)
+	}
+
+	prOutput, prErr := executeLiveCLI(
+		t,
+		"--json", "pr", "list",
+		"--repo", seeded.Key+"/"+repo.Slug,
+		"--state", "all",
+		"--source-branch", branch,
+		"--target-branch", "master",
+		"--limit", "25",
+	)
+	if prErr != nil {
+		t.Fatalf("pr list failed: %v\noutput: %s", prErr, prOutput)
+	}
+
+	prPayload := decodeJSONMap(t, prOutput)
+	pullRequests, ok := prPayload["pull_requests"].([]any)
+	if !ok || len(pullRequests) == 0 {
+		t.Fatalf("expected non-empty pull_requests array, got: %s", prOutput)
+	}
+
+	_, validationErr := executeLiveCLI(t, "pr", "list", "--state", "invalid")
+	if validationErr == nil {
+		t.Fatalf("expected validation error for invalid --state")
 	}
 
 	issueOutput, issueErr := executeLiveCLI(t, "issue", "list")
 	if issueErr == nil {
-		t.Fatalf("expected issue list to be not implemented")
+		t.Fatalf("expected issue command to be unavailable")
 	}
-	if !strings.Contains(issueOutput, "not implemented") && !strings.Contains(issueErr.Error(), "not implemented") {
-		t.Fatalf("expected not implemented message for issue list, output=%s err=%v", issueOutput, issueErr)
+	if !strings.Contains(issueOutput, "unknown command") && !strings.Contains(issueErr.Error(), "unknown command") {
+		t.Fatalf("expected unknown command message for issue command, output=%s err=%v", issueOutput, issueErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- implement bbsc pr list with repository resolution, pagination, state filtering, and optional source/target branch filters
- add dedicated pull request service with mapping and validation
- remove exposed placeholder issue command so help output reflects supported capability
- add/update unit and live integration tests for new behavior
- enforce local commit gating via live+coverage hook task and document it

## Issues
- Closes #12
- Closes #13

## Validation
- task test:live
- task quality:coverage:origin-main
  - combined patch coverage vs origin/main: 90.86% (159/175)
