### PR TITLE
chore(codecov): components + internal-only default coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Coverage/reporting workflow:
 - generated operation contract manifest: `docs/quality/generated-operation-contracts.json`
 - Codecov upload sources in CI are committed combined profiles: `docs/quality/coverage.combined.raw.out` and `docs/quality/coverage.combined.scoped.out`
 - Codecov reports two combined views via flags in `codecov.yml`: `combined_raw` and `combined_scoped`
+- Codecov components in `codecov.yml` split coverage views by `generated-client`, `internal-api`, `cmd`, and `tools`
 - Live + combined metrics remain enforced by committed artifacts generated locally via Task hooks/workflow
 - CI threshold configuration is code-based via `.github/coverage-thresholds.env` (`CI_COVERAGE_MIN_GLOBAL_COMBINED`, `CI_COVERAGE_MIN_PATCH`, `CI_COVERAGE_MIN_PATCH_LINES`, `CI_COVERAGE_MAX_UNCOVERED_SMALL_PATCH`, `CI_COVERAGE_MIN_CONTRACT`)
 - CI ADR floors are enforced even when variables are configured: global >= 85 and patch >= 85

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,33 @@
 codecov:
   require_ci_to_pass: true
 
+component_management:
+  individual_components:
+    - component_id: generated_client
+      name: generated-client
+      paths:
+        - internal/openapi/generated/**
+        - internal/models/generated/**
+
+    - component_id: internal_api
+      name: internal-api
+      flag_regexes:
+        - ^combined_scoped$
+      paths:
+        - internal/**
+
+    - component_id: cmd
+      name: cmd
+      flag_regexes:
+        - ^combined_scoped$
+      paths:
+        - cmd/**
+
+    - component_id: tools
+      name: tools
+      paths:
+        - tools/**
+
 coverage:
   precision: 2
   round: down
@@ -11,10 +38,9 @@ coverage:
         flags:
           - combined_scoped
         paths:
-          - cmd/**
           - internal/**
           - "!internal/openapi/generated/**"
-          - "!internal/models/generated/bitbucket_types.gen.go"
+          - "!internal/models/generated/**"
         target: auto
       combined_raw:
         flags:
@@ -30,17 +56,16 @@ coverage:
           - cmd/**
           - internal/**
           - "!internal/openapi/generated/**"
-          - "!internal/models/generated/bitbucket_types.gen.go"
+          - "!internal/models/generated/**"
         target: auto
     patch:
       default:
         flags:
           - combined_scoped
         paths:
-          - cmd/**
           - internal/**
           - "!internal/openapi/generated/**"
-          - "!internal/models/generated/bitbucket_types.gen.go"
+          - "!internal/models/generated/**"
         target: auto
       combined_raw:
         flags:
@@ -56,7 +81,7 @@ coverage:
           - cmd/**
           - internal/**
           - "!internal/openapi/generated/**"
-          - "!internal/models/generated/bitbucket_types.gen.go"
+          - "!internal/models/generated/**"
         target: auto
 
 ignore:


### PR DESCRIPTION
## Summary
- add Codecov component split (generated-client, internal-api, cmd, tools)
- make default project/patch statuses internal-only
- exclude generated trees under internal/openapi/generated and internal/models/generated

## Notes
- direct push to main is blocked by repository rules, so this PR is used for merge routing
