### PR TITLE
docs(openapi): record requiredApprovers payload deviation

### DIFF
--- a/docs/quality/coverage-report.json
+++ b/docs/quality/coverage-report.json
@@ -1,15 +1,15 @@
 {
   "version": 2,
   "coverage": {
-    "unit_raw_percent": 14.419411487557287,
-    "unit_scoped_percent": 86.24822786441551,
+    "unit_raw_percent": 14.417269884781769,
+    "unit_scoped_percent": 86.23533960561927,
     "live_raw_percent": 17.554571821096015,
     "live_scoped_percent": 58.3042071197411,
-    "combined_raw_percent": 22.409731443011953,
-    "combined_scoped_percent": 88.6325557417193,
+    "combined_raw_percent": 22.407589840236433,
+    "combined_scoped_percent": 88.61966748292306,
     "patch_percent": 100,
     "unit_statements": {
-      "covered": 6733,
+      "covered": 6732,
       "total": 46694
     },
     "live_statements": {
@@ -17,11 +17,11 @@
       "total": 45857
     },
     "combined_statements": {
-      "covered": 10464,
+      "covered": 10463,
       "total": 46694
     },
     "unit_scoped_statements": {
-      "covered": 6692,
+      "covered": 6691,
       "total": 7759
     },
     "live_scoped_statements": {
@@ -29,7 +29,7 @@
       "total": 7725
     },
     "combined_scoped_statements": {
-      "covered": 6877,
+      "covered": 6876,
       "total": 7759
     },
     "patch_lines": {

--- a/docs/quality/coverage.combined.raw.out
+++ b/docs/quality/coverage.combined.raw.out
@@ -2439,7 +2439,7 @@ github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:228.
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:229.1,231.1 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:232.1,232.2 1 0
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:234.1,234.2 1 1
-github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:234.1,236.1 1 1
+github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:234.1,236.1 1 0
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:237.1,237.2 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:237.1,239.1 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:240.1,240.2 1 1

--- a/docs/quality/coverage.combined.scoped.out
+++ b/docs/quality/coverage.combined.scoped.out
@@ -2439,7 +2439,7 @@ github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:228.
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:229.1,231.1 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:232.1,232.2 1 0
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:234.1,234.2 1 1
-github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:234.1,236.1 1 1
+github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:234.1,236.1 1 0
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:237.1,237.2 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:237.1,239.1 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:240.1,240.2 1 1


### PR DESCRIPTION
## Summary
- Register OPENAPI-005 in `docs/openapi/fixes.yaml` for the `requiredApprovers` payload mismatch on pull-request settings updates.
- Document that runtime behavior is object-first with integer fallback for compatibility with environments rejecting the object contract.
- Refresh committed coverage artifacts required by repository hooks.

## Why
Issue #44 asks to formally report this as a deviation from generated OpenAPI behavior. This update preserves existing implementation while making the compatibility rule explicit and auditable per ADR-028.

Closes #44