### PR TITLE
ci(release): install docs tooling before docs deploy step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,17 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+
       - name: Download packaged artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- fix release workflow failure in `Publish versioned docs to GitHub Pages branch` caused by missing `task` binary
- add `Setup Python`, `Setup uv`, and `Setup Task` to the `Publish Release` job before docs deployment
- align release job tooling setup with existing docs-related CI jobs to ensure `task docs:deploy-version` can run

## Validation
- investigated failed run `23045663845` and confirmed error `task: command not found` in docs publish step
- verified workflow diff only updates `.github/workflows/release.yml`