### PR TITLE
refactor(dryrun): merge dryRunProfiles and dryRunPassthroughPaths into unified map

### DIFF
--- a/internal/cli/dryrun.go
+++ b/internal/cli/dryrun.go
@@ -21,8 +21,7 @@ const (
 type dryRunProfile struct {
 	Intent        string
 	Action        string
-	PlanningMode  string
-	Capability    string
+	Stateful      bool
 	CapabilityMsg string
 }
 
@@ -58,121 +57,81 @@ type dryRunPreview struct {
 	Summary      dryRunSummary `json:"summary"`
 }
 
+// dryRunProfiles is the single source of truth for dry-run behaviour on every
+// mutating command. Stateful: true means the command handler performs its own
+// live pre-flight check and writes the dryRunPreview output itself; the
+// interceptor passes through to it unchanged. Stateful: false means the
+// interceptor generates a static (intent-only) preview using newDryRunPreview.
 var dryRunProfiles = map[string]dryRunProfile{
-	"branch create":                                {Intent: "branch.create", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"branch default set":                           {Intent: "branch.default.set", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"branch model update":                          {Intent: "branch.model.update", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"branch restriction create":                    {Intent: "branch.restriction.create", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"branch restriction update":                    {Intent: "branch.restriction.update", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"branch restriction delete":                    {Intent: "branch.restriction.delete", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"build status set":                             {Intent: "build.status.set", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"build required create":                        {Intent: "build.required.create", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"build required update":                        {Intent: "build.required.update", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"build required delete":                        {Intent: "build.required.delete", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"tag create":                                   {Intent: "tag.create", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"tag delete":                                   {Intent: "tag.delete", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo comment create":                          {Intent: "repo.comment.create", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo comment update":                          {Intent: "repo.comment.update", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo comment delete":                          {Intent: "repo.comment.delete", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo settings workflow webhooks create":       {Intent: "repo.webhook.create", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo settings workflow webhooks delete":       {Intent: "repo.webhook.delete", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo settings pull-requests update":           {Intent: "repo.pull-request-settings.update", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo settings pull-requests update-approvers": {Intent: "repo.pull-request-settings.update-approvers", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo settings pull-requests set-strategy":     {Intent: "repo.pull-request-settings.set-strategy", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo admin create":                            {Intent: "repo.admin.create", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo admin fork":                              {Intent: "repo.admin.fork", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo admin update":                            {Intent: "repo.admin.update", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"repo admin delete":                            {Intent: "repo.admin.delete", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"insights report set":                          {Intent: "insights.report.set", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"insights report delete":                       {Intent: "insights.report.delete", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"insights annotation add":                      {Intent: "insights.annotation.add", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"insights annotation delete":                   {Intent: "insights.annotation.delete", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr create":                                    {Intent: "pr.create", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr update":                                    {Intent: "pr.update", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr merge":                                     {Intent: "pr.merge", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr decline":                                   {Intent: "pr.decline", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr reopen":                                    {Intent: "pr.reopen", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr review approve":                            {Intent: "pr.review.approve", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr review unapprove":                          {Intent: "pr.review.unapprove", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr review reviewer add":                       {Intent: "pr.review.reviewer.add", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr review reviewer remove":                    {Intent: "pr.review.reviewer.remove", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr task create":                               {Intent: "pr.task.create", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr task update":                               {Intent: "pr.task.update", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"pr task delete":                               {Intent: "pr.task.delete", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"reviewer condition create":                    {Intent: "reviewer.condition.create", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"reviewer condition update":                    {Intent: "reviewer.condition.update", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"reviewer condition delete":                    {Intent: "reviewer.condition.delete", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"hook enable":                                  {Intent: "hook.enable", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"hook disable":                                 {Intent: "hook.disable", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"hook configure":                               {Intent: "hook.configure", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"project create":                               {Intent: "project.create", Action: "create", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"project update":                               {Intent: "project.update", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"project delete":                               {Intent: "project.delete", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"project permissions users grant":              {Intent: "project.permission.user.grant", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"project permissions users revoke":             {Intent: "project.permission.user.revoke", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"project permissions groups grant":             {Intent: "project.permission.group.grant", Action: "update", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-	"project permissions groups revoke":            {Intent: "project.permission.group.revoke", Action: "delete", PlanningMode: planningModeStatic, Capability: capabilityPartial, CapabilityMsg: "static preview only"},
-}
-
-var dryRunPassthroughPaths = map[string]struct{}{
-	"branch delete": {},
-	"repo settings security permissions users grant":   {},
-	"repo settings security permissions users revoke":  {},
-	"repo settings security permissions groups grant":  {},
-	"repo settings security permissions groups revoke": {},
-	"project permissions users grant":                  {},
-	"project permissions users revoke":                 {},
-	"project permissions groups grant":                 {},
-	"project permissions groups revoke":                {},
-	"hook enable":                                      {},
-	"hook disable":                                     {},
-	"hook configure":                                   {},
-	"repo settings workflow webhooks create":           {},
-	"repo settings workflow webhooks delete":           {},
-	"repo settings pull-requests update":               {},
-	"repo settings pull-requests update-approvers":     {},
-	"repo settings pull-requests set-strategy":         {},
-	"branch create":                                    {},
-	"branch default set":                               {},
-	"branch model update":                              {},
-	"branch restriction create":                        {},
-	"branch restriction update":                        {},
-	"branch restriction delete":                        {},
-	"tag create":                                       {},
-	"tag delete":                                       {},
-	"reviewer condition create":                        {},
-	"reviewer condition update":                        {},
-	"reviewer condition delete":                        {},
-	"repo admin create":                                {},
-	"repo admin fork":                                  {},
-	"repo admin update":                                {},
-	"repo admin delete":                                {},
-	"project create":                                   {},
-	"project update":                                   {},
-	"project delete":                                   {},
-	"pr create":                                        {},
-	"pr update":                                        {},
-	"pr merge":                                         {},
-	"pr decline":                                       {},
-	"pr reopen":                                        {},
-	"pr review approve":                                {},
-	"pr review unapprove":                              {},
-	"pr review reviewer add":                           {},
-	"pr review reviewer remove":                        {},
-	"pr task create":                                   {},
-	"pr task update":                                   {},
-	"pr task delete":                                   {},
-	"build status set":                                 {},
-	"build required create":                            {},
-	"build required update":                            {},
-	"build required delete":                            {},
-	"insights report set":                              {},
-	"insights report delete":                           {},
-	"insights annotation add":                          {},
-	"insights annotation delete":                       {},
-	"repo comment create":                              {},
-	"repo comment update":                              {},
-	"repo comment delete":                              {},
+	// branch
+	"branch delete":                                {Intent: "branch.delete", Action: "delete", Stateful: true},
+	"branch create":                                {Intent: "branch.create", Action: "create", Stateful: true},
+	"branch default set":                           {Intent: "branch.default.set", Action: "update", Stateful: true},
+	"branch model update":                          {Intent: "branch.model.update", Action: "update", Stateful: true},
+	"branch restriction create":                    {Intent: "branch.restriction.create", Action: "create", Stateful: true},
+	"branch restriction update":                    {Intent: "branch.restriction.update", Action: "update", Stateful: true},
+	"branch restriction delete":                    {Intent: "branch.restriction.delete", Action: "delete", Stateful: true},
+	// build
+	"build status set":    {Intent: "build.status.set", Action: "update", Stateful: true},
+	"build required create": {Intent: "build.required.create", Action: "create", Stateful: true},
+	"build required update": {Intent: "build.required.update", Action: "update", Stateful: true},
+	"build required delete": {Intent: "build.required.delete", Action: "delete", Stateful: true},
+	// tag
+	"tag create": {Intent: "tag.create", Action: "create", Stateful: true},
+	"tag delete": {Intent: "tag.delete", Action: "delete", Stateful: true},
+	// repo comment
+	"repo comment create": {Intent: "repo.comment.create", Action: "create", Stateful: true},
+	"repo comment update": {Intent: "repo.comment.update", Action: "update", Stateful: true},
+	"repo comment delete": {Intent: "repo.comment.delete", Action: "delete", Stateful: true},
+	// repo settings
+	"repo settings workflow webhooks create":                  {Intent: "repo.webhook.create", Action: "create", Stateful: true},
+	"repo settings workflow webhooks delete":                  {Intent: "repo.webhook.delete", Action: "delete", Stateful: true},
+	"repo settings pull-requests update":                      {Intent: "repo.pull-request-settings.update", Action: "update", Stateful: true},
+	"repo settings pull-requests update-approvers":            {Intent: "repo.pull-request-settings.update-approvers", Action: "update", Stateful: true},
+	"repo settings pull-requests set-strategy":                {Intent: "repo.pull-request-settings.set-strategy", Action: "update", Stateful: true},
+	"repo settings security permissions users grant":          {Intent: "repo.permission.user.grant", Action: "update", Stateful: true},
+	"repo settings security permissions users revoke":         {Intent: "repo.permission.user.revoke", Action: "delete", Stateful: true},
+	"repo settings security permissions groups grant":         {Intent: "repo.permission.group.grant", Action: "update", Stateful: true},
+	"repo settings security permissions groups revoke":        {Intent: "repo.permission.group.revoke", Action: "delete", Stateful: true},
+	// repo admin
+	"repo admin create": {Intent: "repo.admin.create", Action: "create", Stateful: true},
+	"repo admin fork":   {Intent: "repo.admin.fork", Action: "create", Stateful: true},
+	"repo admin update": {Intent: "repo.admin.update", Action: "update", Stateful: true},
+	"repo admin delete": {Intent: "repo.admin.delete", Action: "delete", Stateful: true},
+	// insights
+	"insights report set":      {Intent: "insights.report.set", Action: "update", Stateful: true},
+	"insights report delete":   {Intent: "insights.report.delete", Action: "delete", Stateful: true},
+	"insights annotation add":  {Intent: "insights.annotation.add", Action: "create", Stateful: true},
+	"insights annotation delete": {Intent: "insights.annotation.delete", Action: "delete", Stateful: true},
+	// pr
+	"pr create":              {Intent: "pr.create", Action: "create", Stateful: true},
+	"pr update":              {Intent: "pr.update", Action: "update", Stateful: true},
+	"pr merge":               {Intent: "pr.merge", Action: "update", Stateful: true},
+	"pr decline":             {Intent: "pr.decline", Action: "update", Stateful: true},
+	"pr reopen":              {Intent: "pr.reopen", Action: "update", Stateful: true},
+	"pr review approve":      {Intent: "pr.review.approve", Action: "update", Stateful: true},
+	"pr review unapprove":    {Intent: "pr.review.unapprove", Action: "update", Stateful: true},
+	"pr review reviewer add":    {Intent: "pr.review.reviewer.add", Action: "update", Stateful: true},
+	"pr review reviewer remove": {Intent: "pr.review.reviewer.remove", Action: "delete", Stateful: true},
+	"pr task create": {Intent: "pr.task.create", Action: "create", Stateful: true},
+	"pr task update": {Intent: "pr.task.update", Action: "update", Stateful: true},
+	"pr task delete": {Intent: "pr.task.delete", Action: "delete", Stateful: true},
+	// reviewer conditions
+	"reviewer condition create": {Intent: "reviewer.condition.create", Action: "create", Stateful: true},
+	"reviewer condition update": {Intent: "reviewer.condition.update", Action: "update", Stateful: true},
+	"reviewer condition delete": {Intent: "reviewer.condition.delete", Action: "delete", Stateful: true},
+	// hook
+	"hook enable":    {Intent: "hook.enable", Action: "update", Stateful: true},
+	"hook disable":   {Intent: "hook.disable", Action: "update", Stateful: true},
+	"hook configure": {Intent: "hook.configure", Action: "update", Stateful: true},
+	// project
+	"project create":                    {Intent: "project.create", Action: "create", Stateful: true},
+	"project update":                    {Intent: "project.update", Action: "update", Stateful: true},
+	"project delete":                    {Intent: "project.delete", Action: "delete", Stateful: true},
+	"project permissions users grant":   {Intent: "project.permission.user.grant", Action: "update", Stateful: true},
+	"project permissions users revoke":  {Intent: "project.permission.user.revoke", Action: "delete", Stateful: true},
+	"project permissions groups grant":  {Intent: "project.permission.group.grant", Action: "update", Stateful: true},
+	"project permissions groups revoke": {Intent: "project.permission.group.revoke", Action: "delete", Stateful: true},
 }
 
 func registerGlobalDryRunInterceptors(root *cobra.Command, options *rootOptions) {
@@ -195,8 +154,7 @@ func registerGlobalDryRunInterceptors(root *cobra.Command, options *rootOptions)
 					return originalRun(cmd, args)
 				}
 
-				path := dryRunCommandPath(cmd)
-				if _, ok := dryRunPassthroughPaths[path]; ok {
+				if profile.Stateful {
 					return originalRun(cmd, args)
 				}
 
@@ -211,9 +169,6 @@ func registerGlobalDryRunInterceptors(root *cobra.Command, options *rootOptions)
 				}
 
 				path := dryRunCommandPath(cmd)
-				if _, ok := dryRunPassthroughPaths[path]; ok {
-					return originalRun(cmd, args)
-				}
 				if !isServerMutatingPath(path) {
 					return originalRun(cmd, args)
 				}
@@ -309,8 +264,8 @@ func newDryRunPreview(profile dryRunProfile, command *cobra.Command, args []stri
 
 	return dryRunPreview{
 		DryRun:       true,
-		PlanningMode: profile.PlanningMode,
-		Capability:   profile.Capability,
+		PlanningMode: planningModeStatic,
+		Capability:   capabilityPartial,
 		Items:        []dryRunItem{item},
 		Summary:      summary,
 	}

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -192,7 +192,7 @@ func TestNewDryRunPreviewSummaries(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		preview := newDryRunPreview(dryRunProfile{Intent: "x", Action: tc.action, PlanningMode: planningModeStatic, Capability: capabilityPartial}, nil, nil)
+		preview := newDryRunPreview(dryRunProfile{Intent: "x", Action: tc.action}, nil, nil)
 		if preview.Summary.Total != 1 || preview.Summary.Supported != 1 {
 			t.Fatalf("expected default totals to be set, got: %+v", preview.Summary)
 		}
@@ -210,10 +210,8 @@ func TestNewDryRunPreviewIncludesRepositoryAndArgs(t *testing.T) {
 	}
 
 	preview := newDryRunPreview(dryRunProfile{
-		Intent:       "project.create",
-		Action:       "create",
-		PlanningMode: planningModeStatic,
-		Capability:   capabilityPartial,
+		Intent:  "project.create",
+		Action:  "create",
 	}, cmd, []string{"PRJ", "--name", "Demo"})
 
 	if preview.Items[0].Target["repository"] != "PRJ/demo" {
@@ -238,10 +236,8 @@ func TestNewDryRunPreviewIncludesInheritedRepositoryFlag(t *testing.T) {
 	root.AddCommand(projectCmd)
 
 	preview := newDryRunPreview(dryRunProfile{
-		Intent:       "project.update",
-		Action:       "update",
-		PlanningMode: planningModeStatic,
-		Capability:   capabilityPartial,
+		Intent:  "project.update",
+		Action:  "update",
 	}, updateCmd, []string{"PRJ"})
 
 	if preview.Items[0].Target["repository"] != "PRJ/inherited" {
@@ -379,6 +375,7 @@ func TestWriteDryRunPreviewWriterErrors(t *testing.T) {
 }
 
 func TestDryRunPassthroughPathCoverage(t *testing.T) {
+	// Every previously-passthrough path must now be a stateful entry in dryRunProfiles.
 	paths := []string{
 		"branch delete",
 		"repo settings security permissions users grant",
@@ -441,8 +438,12 @@ func TestDryRunPassthroughPathCoverage(t *testing.T) {
 	}
 
 	for _, path := range paths {
-		if _, ok := dryRunPassthroughPaths[path]; !ok {
-			t.Fatalf("expected passthrough entry for %q", path)
+		profile, ok := dryRunProfiles[path]
+		if !ok {
+			t.Fatalf("expected dryRunProfiles entry for %q", path)
+		}
+		if !profile.Stateful {
+			t.Fatalf("expected Stateful=true for %q", path)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #103.

Replaces the two parallel maps (`dryRunProfiles` and `dryRunPassthroughPaths`) with a single `dryRunProfiles` map. Each entry now carries a `Stateful bool` field that encodes which dry-run path the command takes — instead of the previous approach of maintaining a separate set that had to stay in sync.

## What changed

### `dryRunProfile` struct
- Removed `PlanningMode string` and `Capability string` (were always duplicates of `Stateful`)
- Added `Stateful bool`

### `dryRunProfiles` map
- All 53 existing entries updated to `Stateful: true` (accurate, since stateful planning was already implemented for all of them)
- The 5 paths that previously lived only in `dryRunPassthroughPaths` (`branch delete`, `repo settings security permissions *`) are promoted into the map with their correct `Intent`/`Action` metadata

### `dryRunPassthroughPaths` map
- Deleted entirely

### `registerGlobalDryRunInterceptors`
- Profile branch: checks `profile.Stateful` instead of a second map lookup
- Non-profile branch: no longer needs to check `dryRunPassthroughPaths`; those commands now have profiles

### `newDryRunPreview`
- No longer reads `profile.PlanningMode`/`profile.Capability` from the profile; uses the `planningModeStatic`/`capabilityPartial` constants directly (this function is only ever reached for `Stateful: false` entries)

### Tests
- Updated `TestDryRunPassthroughPathCoverage` to assert membership and `Stateful: true` in `dryRunProfiles` rather than `dryRunPassthroughPaths`
- Updated `dryRunProfile` literals in tests to drop the removed fields

## Why

The old structure had a correctness risk: a new command could be added to one map but not the other, silently breaking dry-run behavior. The `Stateful bool` field on the entry makes the intent explicit and co-located with the rest of the command's metadata.