### PR TITLE
fix(mcp): move set_build_status behind --yolo

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -73,8 +73,8 @@ func AllSpecs() []Spec {
 		{specCreateTag().Tool, specCreateTag().Handler, true},
 		// Build / quality group
 		{specGetBuildStatus().Tool, specGetBuildStatus().Handler, true},
-		// Setting a build status manipulates CI state — safe by default (easily overridden).
-		{specSetBuildStatus().Tool, specSetBuildStatus().Handler, true},
+		// Setting a build status is a write operation that affects CI signal — requires --yolo.
+		{specSetBuildStatus().Tool, specSetBuildStatus().Handler, false},
 		{specListRequiredBuilds().Tool, specListRequiredBuilds().Handler, true},
 		// Commit group
 		{specListCommits().Tool, specListCommits().Handler, true},

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -139,22 +139,33 @@ func TestSafeSpecsSubsetOfAllSpecs(t *testing.T) {
 
 // TestMergePullRequestIsUnsafe verifies the merge tool is not in the safe set.
 func TestMergePullRequestIsUnsafe(t *testing.T) {
+	unsafeTools := []string{"merge_pull_request", "set_build_status"}
+	safeByName := make(map[string]bool)
 	for _, s := range SafeSpecs() {
-		if s.Tool.Name == "merge_pull_request" {
-			t.Fatal("merge_pull_request must not appear in SafeSpecs")
+		safeByName[s.Tool.Name] = true
+	}
+	allByName := make(map[string]bool)
+	for _, s := range AllSpecs() {
+		if s.Safe {
+			allByName[s.Tool.Name] = true
 		}
 	}
-	found := false
-	for _, s := range AllSpecs() {
-		if s.Tool.Name == "merge_pull_request" {
-			found = true
-			if s.Safe {
-				t.Fatal("merge_pull_request must have Safe=false in AllSpecs")
+	for _, name := range unsafeTools {
+		if safeByName[name] {
+			t.Errorf("%q must not appear in SafeSpecs", name)
+		}
+		if allByName[name] {
+			t.Errorf("%q must have Safe=false in AllSpecs", name)
+		}
+		found := false
+		for _, s := range AllSpecs() {
+			if s.Tool.Name == name {
+				found = true
 			}
 		}
-	}
-	if !found {
-		t.Fatal("merge_pull_request not found in AllSpecs")
+		if !found {
+			t.Errorf("%q not found in AllSpecs", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`set_build_status` was classified as safe by default in #108, but build status is a write operation that affects CI gating logic — required builds, PR merge checks — in ways not immediately visible to the operator. A misfire silently changes what other systems rely on, which is closer in impact to `merge_pull_request` than to `add_pr_comment`.

## Change

Moved `set_build_status` to `Safe: false`. It now requires `--yolo` / `--allow-writes`.

**Default (safe mode) — 18 tools:** all previous safe tools minus `set_build_status`.
**Requires `--yolo` — 2 tools:** `merge_pull_request`, `set_build_status`.