### PR TITLE
docs: limit changelog TOC to versions

### DIFF
--- a/docs/site/changelog.md
+++ b/docs/site/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v1.11.8](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.11.8)
+
+Published: 2026-04-06
+
+Changes since v1.11.7.
+
+Compare: [v1.11.7...v1.11.8](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.11.7...v1.11.8)
+
+**Fixes**
+- harden docs changelog renderer ([31da64a](https://github.com/vriesdemichael/bitbucket-server-cli/commit/31da64a58cc6078eae1751f614cd52d6bb6de8a7))
+
+**Docs**
+- fix changelog publishing and refresh llms guide ([0b8a352](https://github.com/vriesdemichael/bitbucket-server-cli/commit/0b8a352c718364af777c3c41e443eb68de6bea6e))
+
 ## [v1.11.7](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.11.7)
 
 Published: 2026-04-06
@@ -8,7 +22,7 @@ Changes since v1.11.6.
 
 Compare: [v1.11.6...v1.11.7](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.11.6...v1.11.7)
 
-### Docs
+**Docs**
 - improve nav and table legibility ([9540d95](https://github.com/vriesdemichael/bitbucket-server-cli/commit/9540d9565ff501a6f6e4d052bbcd026bc93c1165))
 
 ## [v1.11.6](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.11.6)
@@ -19,7 +33,7 @@ Changes since v1.11.5.
 
 Compare: [v1.11.5...v1.11.6](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.11.5...v1.11.6)
 
-### Docs
+**Docs**
 - tune landing page scale and secondary buttons ([6366fb0](https://github.com/vriesdemichael/bitbucket-server-cli/commit/6366fb0d742101cf3000fcfd35b2a12db947e8bd))
 
 ## [v1.11.5](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.11.5)
@@ -30,7 +44,7 @@ Changes since v1.11.4.
 
 Compare: [v1.11.4...v1.11.5](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.11.4...v1.11.5)
 
-### Docs
+**Docs**
 - refine landing page readability ([31cd30d](https://github.com/vriesdemichael/bitbucket-server-cli/commit/31cd30da2229055fb6966cd8a3c93be4ec00063c))
 
 ## [v1.11.4](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.11.4)
@@ -41,7 +55,7 @@ Changes since v1.11.3.
 
 Compare: [v1.11.3...v1.11.4](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.11.3...v1.11.4)
 
-### Docs
+**Docs**
 - fix scrolling docs background ([30e3728](https://github.com/vriesdemichael/bitbucket-server-cli/commit/30e37280ce46da6d133e142229402c476934d6e4))
 
 ## [v1.11.3](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.11.3)
@@ -52,7 +66,7 @@ Changes since v1.11.2.
 
 Compare: [v1.11.2...v1.11.3](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.11.2...v1.11.3)
 
-### Docs
+**Docs**
 - fix homepage front matter indentation ([280094d](https://github.com/vriesdemichael/bitbucket-server-cli/commit/280094d8321c53a2c7b8cf9c7b972fce385b6f49))
 - customize MkDocs visual design ([e539d3a](https://github.com/vriesdemichael/bitbucket-server-cli/commit/e539d3aa995435f459b2ce519607c4b9ba84e5cc))
 - enable mike version picker in MkDocs Material ([17ec68d](https://github.com/vriesdemichael/bitbucket-server-cli/commit/17ec68d8237384b111ef829e657f4d3152e7753d))
@@ -66,7 +80,7 @@ Changes since v1.11.1.
 
 Compare: [v1.11.1...v1.11.2](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.11.1...v1.11.2)
 
-### Docs
+**Docs**
 - improve README quick start section ([ce4f869](https://github.com/vriesdemichael/bitbucket-server-cli/commit/ce4f86983a4035c2a4433b49e1ccb0a5490643fb))
 
 ## [v1.11.1](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.11.1)
@@ -77,7 +91,7 @@ Changes since v1.11.0.
 
 Compare: [v1.11.0...v1.11.1](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.11.0...v1.11.1)
 
-### CI
+**CI**
 - add repo-token to setup-task to bypass rate limiting ([105722e](https://github.com/vriesdemichael/bitbucket-server-cli/commit/105722ea1d5fa03d344dd55d48ba9f94caf8b3a5))
 
 ## [v1.11.0](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.11.0)
@@ -88,14 +102,14 @@ Changes since v1.10.1.
 
 Compare: [v1.10.1...v1.11.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.10.1...v1.11.0)
 
-### Features
+**Features**
 - publish JSON schemas for per-command --json output contract ([496bf79](https://github.com/vriesdemichael/bitbucket-server-cli/commit/496bf79385a4252ac8f026e2f9cd04a07bca2377))
 - publish changelog to docs site on each release ([f0d1ec0](https://github.com/vriesdemichael/bitbucket-server-cli/commit/f0d1ec0445737d4b078b87a150a0d834f5ebec94))
 
-### Tests
+**Tests**
 - add coverage for output schema functions to satisfy patch gate ([6307f89](https://github.com/vriesdemichael/bitbucket-server-cli/commit/6307f897816c223fc979b968398cdb51cd3b878f))
 
-### CI
+**CI**
 - remove changelog push-to-main step from release workflow ([6167767](https://github.com/vriesdemichael/bitbucket-server-cli/commit/6167767317f63ed9723ade6fed873ff159b781f0))
 
 ## [v1.10.1](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.10.1)
@@ -106,10 +120,10 @@ Changes since v1.10.0.
 
 Compare: [v1.10.0...v1.10.1](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.10.0...v1.10.1)
 
-### Fixes
+**Fixes**
 - ci: switch changelog to release-asset download, add CHANGELOG.md reference ([f14f498](https://github.com/vriesdemichael/bitbucket-server-cli/commit/f14f4989a5ca644c3bf30e54c868dfcdbbff58ca))
 
-### CI
+**CI**
 - remove unused os import and html-escape changelog fields ([6286421](https://github.com/vriesdemichael/bitbucket-server-cli/commit/6286421b09ea9df55c41879f53bee34b34e770d5))
 
 ## [v1.10.0](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.10.0)
@@ -120,10 +134,10 @@ Changes since v1.9.2.
 
 Compare: [v1.9.2...v1.10.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.9.2...v1.10.0)
 
-### Features
+**Features**
 - publish changelog to docs site on each release ([c55bbd7](https://github.com/vriesdemichael/bitbucket-server-cli/commit/c55bbd7574ba29f38dc59c37ed5d08430a1b56f1))
 
-### Docs
+**Docs**
 - generate missing ADR markdown exports for 038-040 ([b2468d1](https://github.com/vriesdemichael/bitbucket-server-cli/commit/b2468d148857b5a8a898bf8e5fef37e984d3e356))
 
 ## [v1.9.2](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.9.2)
@@ -134,17 +148,17 @@ Changes since v1.9.1.
 
 Compare: [v1.9.1...v1.9.2](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.9.1...v1.9.2)
 
-### Fixes
+**Fixes**
 - ci: drop byte-for-byte coverage report verify ([20c9af4](https://github.com/vriesdemichael/bitbucket-server-cli/commit/20c9af4b266188e229c4041b15bd7e776cc8cca2))
 - ci: vendor libfaketime tarball to eliminate network dependency in Docker build ([b0d18e3](https://github.com/vriesdemichael/bitbucket-server-cli/commit/b0d18e36819f7a51ea4c0a968fa47997d2079c1a))
 - ci: two-stage Dockerfile build + license apply in bootstrap ([fe7d0d6](https://github.com/vriesdemichael/bitbucket-server-cli/commit/fe7d0d65dbf530cd38160ed3276ad90deef3727b))
 - ci: address Copilot review comments on live-tests job ([73b05a6](https://github.com/vriesdemichael/bitbucket-server-cli/commit/73b05a68b03bc130d46972d110f796644d3a4efa))
 - ci: correct bootstrap script and switch to named volumes ([5a24737](https://github.com/vriesdemichael/bitbucket-server-cli/commit/5a24737434ad3b944fb719bf6e695d8f2986f696))
 
-### Docs
+**Docs**
 - quality: refresh coverage artifacts ([409cdf0](https://github.com/vriesdemichael/bitbucket-server-cli/commit/409cdf0fa7644ac4b15423e630143c87d0612793))
 
-### CI
+**CI**
 - opt into Node.js 24 actions + move Codecov upload to live-tests ([9f6c34a](https://github.com/vriesdemichael/bitbucket-server-cli/commit/9f6c34a61cc3ef0a4c637c8059bec1e196f2b331))
 - remove coverage-report-policy job (superseded by live-tests) ([c2c057d](https://github.com/vriesdemichael/bitbucket-server-cli/commit/c2c057d6f61ea7ffd0db3db1560061811920102e))
 - add live integration test job with Bitbucket DC bootstrap ([56eb25b](https://github.com/vriesdemichael/bitbucket-server-cli/commit/56eb25be2384e2cb21280c9ad71a26345c6843da))
@@ -157,7 +171,7 @@ Changes since v1.9.0.
 
 Compare: [v1.9.0...v1.9.1](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.9.0...v1.9.1)
 
-### Fixes
+**Fixes**
 - mcp: move set_build_status behind --yolo ([4bebe4c](https://github.com/vriesdemichael/bitbucket-server-cli/commit/4bebe4c40f553594485945777c0f09f1713a7bf6))
 
 ## [v1.9.0](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.9.0)
@@ -168,10 +182,10 @@ Changes since v1.8.2.
 
 Compare: [v1.8.2...v1.9.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.8.2...v1.9.0)
 
-### Features
+**Features**
 - mcp: restrict serve to safe tools by default; add --yolo for full access ([2d6cac1](https://github.com/vriesdemichael/bitbucket-server-cli/commit/2d6cac137fb101946457052c2ef9f3a240152711))
 
-### Fixes
+**Fixes**
 - config: default bare hostnames to https:// in normalizeURL ([a50a2af](https://github.com/vriesdemichael/bitbucket-server-cli/commit/a50a2af45c0910a05608c5a624ece84ee32a4a6b))
 
 ## [v1.8.2](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.8.2)
@@ -182,7 +196,7 @@ Changes since v1.8.1.
 
 Compare: [v1.8.1...v1.8.2](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.8.1...v1.8.2)
 
-### Refactors
+**Refactors**
 - dryrun: merge dryRunProfiles and dryRunPassthroughPaths into unified map ([2076c3d](https://github.com/vriesdemichael/bitbucket-server-cli/commit/2076c3d59efc61f407aeee94fd17c842d4e2d5f0))
 
 ## [v1.8.1](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.8.1)
@@ -193,7 +207,7 @@ Changes since v1.8.0.
 
 Compare: [v1.8.0...v1.8.1](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.8.0...v1.8.1)
 
-### Chores
+**Chores**
 - docs: remove outdated migration checklist ([5b88d15](https://github.com/vriesdemichael/bitbucket-server-cli/commit/5b88d15eb019969ffe56fd91f5a56c48f8155c46))
 
 ## [v1.8.0](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.8.0)
@@ -204,15 +218,15 @@ Changes since v1.7.0.
 
 Compare: [v1.7.0...v1.8.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.7.0...v1.8.0)
 
-### Features
+**Features**
 - ai: add bb ai mcp and bb ai skill CLI commands ([e708036](https://github.com/vriesdemichael/bitbucket-server-cli/commit/e708036ee2e3a1cb8eea246dd576e5476985f4a9))
 - ai: add internal/mcp package with 20 MCP tool specs ([afcc856](https://github.com/vriesdemichael/bitbucket-server-cli/commit/afcc85676361b89984986296491ed27394066243))
 - ai: add skills/bb/SKILL.md agent skill for coding sessions ([b226ca7](https://github.com/vriesdemichael/bitbucket-server-cli/commit/b226ca7b8cea3c80ac3888e7befd8c20f1a26208))
 
-### Docs
+**Docs**
 - decisions: add ADRs 038-040 for bb ai subcommand, MCP server and skill distribution ([e96f894](https://github.com/vriesdemichael/bitbucket-server-cli/commit/e96f894561e42239c7d45f11f4d08a38262ef354))
 
-### Chores
+**Chores**
 - deps: add github.com/mark3labs/mcp-go v0.46.0 ([f931ed9](https://github.com/vriesdemichael/bitbucket-server-cli/commit/f931ed97618ba390cb52a2a7f11f4b04cb66c5a6))
 
 ## [v1.7.0](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.7.0)
@@ -223,10 +237,10 @@ Changes since v1.6.0.
 
 Compare: [v1.6.0...v1.7.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.6.0...v1.7.0)
 
-### Features
+**Features**
 - rich colored terminal output with lipgloss ([73a122d](https://github.com/vriesdemichael/bitbucket-server-cli/commit/73a122de17cc8f3cde0cef8a3400992a20709ea2))
 
-### Refactors
+**Refactors**
 - style: address Copilot PR review comments ([61431ae](https://github.com/vriesdemichael/bitbucket-server-cli/commit/61431ae6efa78cf609e197f9bc4bd93bedc4d93c))
 
 ## [v1.6.0](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.6.0)
@@ -237,10 +251,10 @@ Changes since v1.5.0.
 
 Compare: [v1.5.0...v1.6.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.5.0...v1.6.0)
 
-### Features
+**Features**
 - cli: add agent notice to bb --help for issue reporting ([a4f86e9](https://github.com/vriesdemichael/bitbucket-server-cli/commit/a4f86e92fe5d8d5417bea7263c50f945c86a0ef8))
 
-### Fixes
+**Fixes**
 - cli: use American spelling 'behavior' for consistency ([87a87bc](https://github.com/vriesdemichael/bitbucket-server-cli/commit/87a87bc9702fe5b666841b545207b57e14f3b223))
 
 ## [v1.5.0](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.5.0)
@@ -251,22 +265,22 @@ Changes since v1.4.1.
 
 Compare: [v1.4.1...v1.5.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.4.1...v1.5.0)
 
-### Features
+**Features**
 - pr: add pr build status subcommand ([de7263d](https://github.com/vriesdemichael/bitbucket-server-cli/commit/de7263d03f847b0c8f063b0dab5ceb7414ce2e64))
 - cli: expose --version flag via cobra Version field ([1350092](https://github.com/vriesdemichael/bitbucket-server-cli/commit/135009206b759d8332b8592847c736c2f067f0fa))
 
-### Fixes
+**Fixes**
 - multi: address PR review comments ([44c76c0](https://github.com/vriesdemichael/bitbucket-server-cli/commit/44c76c071bd1e4334c9fc28539537f302427dc83))
 - auth: token-url resolves per-user PAT URL when authenticated ([13c5d24](https://github.com/vriesdemichael/bitbucket-server-cli/commit/13c5d24ecd31cec8262b9d5853a7ed74f8e7866a))
 - config: resolve stored credentials across http/https schemes ([f1f5bf7](https://github.com/vriesdemichael/bitbucket-server-cli/commit/f1f5bf76d681d61199de68d17bed226a4c7bd395))
 - repo-clone: implement ssh→token→prompt auth fallback order ([fb685f9](https://github.com/vriesdemichael/bitbucket-server-cli/commit/fb685f9e2150c66b7806e2e04fea8a1b9077dfe7))
 
-### Docs
+**Docs**
 - quality: refresh coverage artifacts after PR comment fixes ([5be4af5](https://github.com/vriesdemichael/bitbucket-server-cli/commit/5be4af503ac822c2c3cfdbc1ddf641aa232d1005))
 - quality: re-sync coverage artifacts after fresh live run ([f9c2902](https://github.com/vriesdemichael/bitbucket-server-cli/commit/f9c29027f77613793633176f32e4b27fb15773c1))
 - quality: refresh coverage report artifacts for issues #88 #90 #91 #92 #94 ([bfa888d](https://github.com/vriesdemichael/bitbucket-server-cli/commit/bfa888df825227f87516131885ef71eaf88690df))
 
-### Chores
+**Chores**
 - add AGENTS.md with rebase + quality-artifact instructions ([e781c6b](https://github.com/vriesdemichael/bitbucket-server-cli/commit/e781c6bf3c54e9e5d10113d05fdfaadd685d2870))
 - docker: update dev environment with faketime support and postgres 17 ([5355d57](https://github.com/vriesdemichael/bitbucket-server-cli/commit/5355d57fe34afcaeb89189ff29a0ce84f116cd34))
 
@@ -278,11 +292,11 @@ Changes since v1.4.0.
 
 Compare: [v1.4.0...v1.4.1](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.4.0...v1.4.1)
 
-### Fixes
+**Fixes**
 - address PR review feedback on repo list tests and docs ([1d2d495](https://github.com/vriesdemichael/bitbucket-server-cli/commit/1d2d49546635bf84bcbcd992a73d6450209c3d14))
 - remove hardcoded host fallback, make auth login host positional, cap repo list --limit as total ([e201db9](https://github.com/vriesdemichael/bitbucket-server-cli/commit/e201db92e806100134062ef3fd451aa55f5d4057))
 
-### Docs
+**Docs**
 - quality: sync coverage artifacts with current live run ([e53f3cb](https://github.com/vriesdemichael/bitbucket-server-cli/commit/e53f3cbfce40d1c95d321266edc5f3f82098dbcc))
 - quality: refresh coverage artifacts after review fixes ([151de6f](https://github.com/vriesdemichael/bitbucket-server-cli/commit/151de6fc43f518611f17d2150660602ecf6bebff))
 
@@ -294,14 +308,14 @@ Changes since v1.3.1.
 
 Compare: [v1.3.1...v1.4.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.3.1...v1.4.0)
 
-### Features
+**Features**
 - cli: add repo/project permissions show commands (issue #81) ([de7674d](https://github.com/vriesdemichael/bitbucket-server-cli/commit/de7674d8c91cdb91a566ba1679143351a03af82b))
 
-### Fixes
+**Fixes**
 - test: replace t.Context() with context.Background() for Go 1.22 compat ([ca51e50](https://github.com/vriesdemichael/bitbucket-server-cli/commit/ca51e50b44b3e2a38faff8e5d52a713c10ae53a7))
 - review: address PR #83 Copilot review comments ([04ed3d6](https://github.com/vriesdemichael/bitbucket-server-cli/commit/04ed3d66457d9e2dbd2d518300f3c9dd23fe3be2))
 
-### Docs
+**Docs**
 - quality: refresh committed coverage report artifacts ([ea2e36c](https://github.com/vriesdemichael/bitbucket-server-cli/commit/ea2e36ce3e648598db71d7fb7f899f009ee8d9fe))
 - quality: refresh coverage report and command reference artifacts ([c7f0568](https://github.com/vriesdemichael/bitbucket-server-cli/commit/c7f056809b1a5d3eff9ead5d69deb8773f1db58d))
 
@@ -313,13 +327,13 @@ Changes since v1.3.0.
 
 Compare: [v1.3.0...v1.3.1](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.3.0...v1.3.1)
 
-### Fixes
+**Fixes**
 - test: stabilize dry-run tests in CI ([3a6d3c9](https://github.com/vriesdemichael/bitbucket-server-cli/commit/3a6d3c974f3518215075ca97a24c3e34577f5128))
 - test: support Go 1.22 in permission checker tests ([7997b99](https://github.com/vriesdemichael/bitbucket-server-cli/commit/7997b990939e14ace0d60e01d249f267f861dd19))
 - cli: address permission precheck review feedback ([8afb652](https://github.com/vriesdemichael/bitbucket-server-cli/commit/8afb652501c0a5895756dd80e1dc517bec3df06b))
 - cli: surface dry-run auth failures before planning ([8f9b3cc](https://github.com/vriesdemichael/bitbucket-server-cli/commit/8f9b3cc7a7b0fb500a6922785d56754ddf4179a2))
 
-### Docs
+**Docs**
 - quality: refresh committed coverage report artifacts ([62faaa5](https://github.com/vriesdemichael/bitbucket-server-cli/commit/62faaa56c0a539953e933edaa3c295fe7914538c))
 - quality: refresh committed coverage report artifacts ([285a892](https://github.com/vriesdemichael/bitbucket-server-cli/commit/285a892daf7dcda59d3fa3eb00c392a05f4ccae4))
 
@@ -331,13 +345,13 @@ Changes since v1.2.0.
 
 Compare: [v1.2.0...v1.3.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.2.0...v1.3.0)
 
-### Features
+**Features**
 - cli: add gh-style browse and repo clone parity for Bitbucket ([0e74130](https://github.com/vriesdemichael/bitbucket-server-cli/commit/0e74130012ee3ce2d29279404e06025a30e3eb90))
 
-### Fixes
+**Fixes**
 - cli: address review comments for browse and clone commands ([133252b](https://github.com/vriesdemichael/bitbucket-server-cli/commit/133252b94437cf810569f0dd69195e57f51f38be))
 
-### Docs
+**Docs**
 - quality: refresh committed coverage report artifacts ([0b32584](https://github.com/vriesdemichael/bitbucket-server-cli/commit/0b32584e33d7218e2b94053f07b34f675dd779cd))
 - quality: refresh committed coverage report artifacts ([5245340](https://github.com/vriesdemichael/bitbucket-server-cli/commit/5245340f1a8b41e0cd0c67c7efdc4ae065e22240))
 
@@ -349,10 +363,10 @@ Changes since v1.1.1.
 
 Compare: [v1.1.1...v1.2.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.1.1...v1.2.0)
 
-### Features
+**Features**
 - auth: add whoami identity and PAT onboarding ([f56b8d3](https://github.com/vriesdemichael/bitbucket-server-cli/commit/f56b8d358fa97d6bb2851ca38c4b60c32f22abb8))
 
-### Docs
+**Docs**
 - quality: refresh coverage report artifacts ([09f0a6c](https://github.com/vriesdemichael/bitbucket-server-cli/commit/09f0a6c9ecd5a69e4e7499038a07a748dabe45ad))
 - quality: refresh coverage report artifacts ([67afad4](https://github.com/vriesdemichael/bitbucket-server-cli/commit/67afad41cab5fa9a22b43e2267c3f690a4b4fd0a))
 
@@ -364,7 +378,7 @@ Changes since v1.1.0.
 
 Compare: [v1.1.0...v1.1.1](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.1.0...v1.1.1)
 
-### Docs
+**Docs**
 - readme: reposition as adopter-focused landing page ([1890372](https://github.com/vriesdemichael/bitbucket-server-cli/commit/1890372d3241bf93c4b3a80bf0b932886c42ec29))
 - site: address PR feedback on auth examples and precedence ([de93894](https://github.com/vriesdemichael/bitbucket-server-cli/commit/de93894f98ecfcaa28ef2a5157d94d151346ca19))
 - site: add repo discovery and server switching guidance ([122ae89](https://github.com/vriesdemichael/bitbucket-server-cli/commit/122ae89d03906199e88c11a05769799789d4cbec))
@@ -377,10 +391,10 @@ Changes since v1.0.2.
 
 Compare: [v1.0.2...v1.1.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.0.2...v1.1.0)
 
-### Features
+**Features**
 - docs: restructure docs and automate generated references ([c86b87a](https://github.com/vriesdemichael/bitbucket-server-cli/commit/c86b87a8ac5a184932418e3c0c6232a1b784a5c0))
 
-### Docs
+**Docs**
 - quality: refresh committed coverage report artifacts ([1d3cd03](https://github.com/vriesdemichael/bitbucket-server-cli/commit/1d3cd039698af83a802e2acaad03d76b2fe0054e))
 - quality: refresh committed coverage report artifacts ([51b80d5](https://github.com/vriesdemichael/bitbucket-server-cli/commit/51b80d587055216f81b4a222993acc8f704e543d))
 
@@ -392,10 +406,10 @@ Changes since v1.0.1.
 
 Compare: [v1.0.1...v1.0.2](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.0.1...v1.0.2)
 
-### Docs
+**Docs**
 - quality: refresh committed coverage report artifacts ([2548a9f](https://github.com/vriesdemichael/bitbucket-server-cli/commit/2548a9f0253f8bd312335edd484e3b89ecd3a2d7))
 
-### CI
+**CI**
 - codecov: report scoped coverage only ([c7d7bb3](https://github.com/vriesdemichael/bitbucket-server-cli/commit/c7d7bb3d7c7faab03a06a00be25d8681f76abe27))
 
 ## [v1.0.1](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.0.1)
@@ -406,7 +420,7 @@ Changes since v1.0.0.
 
 Compare: [v1.0.0...v1.0.1](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v1.0.0...v1.0.1)
 
-### CI
+**CI**
 - release: install docs tooling before docs deploy step ([5452c0b](https://github.com/vriesdemichael/bitbucket-server-cli/commit/5452c0bf8d491070fc08d41ce272e67685011b2f))
 
 ## [v1.0.0](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v1.0.0)
@@ -417,215 +431,16 @@ Changes since v0.3.0.
 
 Compare: [v0.3.0...v1.0.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v0.3.0...v1.0.0)
 
-### ⚠ Breaking Changes
+**⚠ Breaking Changes**
 - rename public bbsc surface to bb ([10463c7](https://github.com/vriesdemichael/bitbucket-server-cli/commit/10463c7e174ec49b41e3b79d0db80cc464f979aa)) — switch CLI identity to bb with BB_* env variables, bb.machine v2 envelope, bb.io/v1alpha1 bulk API identifiers, and bb release artifacts.
 
-### Features
+**Features**
 - docs: add versioned mkdocs foundation with uv ([f925f86](https://github.com/vriesdemichael/bitbucket-server-cli/commit/f925f86cf0c5c2c48626d92ed4df8007e5f9655a))
 - cli: rename public bbsc surface to bb ([10463c7](https://github.com/vriesdemichael/bitbucket-server-cli/commit/10463c7e174ec49b41e3b79d0db80cc464f979aa))
 
-### Docs
+**Docs**
 - quality: refresh committed coverage report artifacts ([9e9400e](https://github.com/vriesdemichael/bitbucket-server-cli/commit/9e9400e4f43ae64439733d61d8c209d78fa851e9))
 
-### CI
+**CI**
 - hooks: run docs validation before coverage verify ([ee02b63](https://github.com/vriesdemichael/bitbucket-server-cli/commit/ee02b63f6343b6977fcac853d3c03bc0f07f58ad))
 - docs: add bootstrap + pre-push mkdocs validation ([018cb69](https://github.com/vriesdemichael/bitbucket-server-cli/commit/018cb69944e7e9bdff6b0da737781927ea953e90))
-
-## [v0.3.0](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v0.3.0)
-
-Published: 2026-03-12
-
-Changes since v0.2.1.
-
-Compare: [v0.2.1...v0.3.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v0.2.1...v0.3.0)
-
-### Features
-- cli: version machine-mode JSON output envelope ([e900993](https://github.com/vriesdemichael/bitbucket-server-cli/commit/e90099300ed1bd456f87337b20f02fbd24d9cc5d))
-
-### Refactors
-- cli: centralize JSON envelope writer contract ([1e6c5c0](https://github.com/vriesdemichael/bitbucket-server-cli/commit/1e6c5c064711b098f42f8c54958a2b49cc3f38fa))
-
-### Docs
-- quality: refresh committed coverage report artifacts ([ef45ac1](https://github.com/vriesdemichael/bitbucket-server-cli/commit/ef45ac1ae5ef9d932c3d11f34c0ecd6823e80682))
-- quality: refresh committed coverage report artifacts ([91aab37](https://github.com/vriesdemichael/bitbucket-server-cli/commit/91aab378446c3d65fbd53b05132782e59c9c459d))
-- quality: refresh committed coverage report artifacts ([4dc078d](https://github.com/vriesdemichael/bitbucket-server-cli/commit/4dc078d2ae26db11d223e35d04aa13eb95bcf859))
-- quality: refresh committed coverage report artifacts ([52d8dee](https://github.com/vriesdemichael/bitbucket-server-cli/commit/52d8deeedcf38aae5a9f1c2ad116991f2b39e90b))
-
-## [v0.2.1](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v0.2.1)
-
-Published: 2026-03-12
-
-Changes since v0.2.0.
-
-Compare: [v0.2.0...v0.2.1](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v0.2.0...v0.2.1)
-
-### Docs
-- quality: refresh committed coverage report artifacts ([e4ca425](https://github.com/vriesdemichael/bitbucket-server-cli/commit/e4ca425faa36cf357973d1ff64d4ebd760d03b01))
-- quality: refresh committed coverage report artifacts ([10d58af](https://github.com/vriesdemichael/bitbucket-server-cli/commit/10d58af1b2ac9eeb4ef62e1e359808cf1e56ee8b))
-- openapi: record requiredApprovers payload deviation ([2321d88](https://github.com/vriesdemichael/bitbucket-server-cli/commit/2321d88d21d664bba2726c990af8f3e67f34b664))
-
-## [v0.2.0](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v0.2.0)
-
-Published: 2026-03-12
-
-Changes since v0.1.0.
-
-Compare: [v0.1.0...v0.2.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v0.1.0...v0.2.0)
-
-### Features
-- cli: expand stateful dry-run coverage ([0be9363](https://github.com/vriesdemichael/bitbucket-server-cli/commit/0be9363c53e1f571ddb65281285bfb459d92aab5))
-- cli: add global dry-run planning previews for server mutations ([53d15d3](https://github.com/vriesdemichael/bitbucket-server-cli/commit/53d15d36c25006473d34d590b87603174bbc1509))
-
-### Fixes
-- cli: address dry-run review feedback ([b294681](https://github.com/vriesdemichael/bitbucket-server-cli/commit/b294681562934e5c6b8ff686a56929d593360fef))
-
-### Docs
-- quality: refresh committed coverage artifacts ([dec36d0](https://github.com/vriesdemichael/bitbucket-server-cli/commit/dec36d03e83cc3bc3e6062b7747fcd35bbcb2721))
-
-## [v0.1.0](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v0.1.0)
-
-Published: 2026-03-11
-
-Changes since v0.0.4.
-
-Compare: [v0.0.4...v0.1.0](https://github.com/vriesdemichael/bitbucket-server-cli/compare/v0.0.4...v0.1.0)
-
-### Features
-- ci: automate main-branch release flow ([246c641](https://github.com/vriesdemichael/bitbucket-server-cli/commit/246c641549c1d89546425168c3db128f86f5fb6a))
-- cli: add server switching and git context inference ([5e3e445](https://github.com/vriesdemichael/bitbucket-server-cli/commit/5e3e445b6d55f9ffa7fe44a87f778739a1df327c))
-- bulk: add runtime JSON schema validation for bulk plan and apply ([8478e89](https://github.com/vriesdemichael/bitbucket-server-cli/commit/8478e89145e41f7cd3f494e21e4e4c693252e0be))
-- diagnostics: add structured safe logging controls ([1af91e5](https://github.com/vriesdemichael/bitbucket-server-cli/commit/1af91e5f0b177b5f3c921919f90bd1d81f2c678f))
-- cli: modularize root command construction ([32be3ae](https://github.com/vriesdemichael/bitbucket-server-cli/commit/32be3aed8ac8899f8c82b30fc18b2855e59e1c09))
-
-### Fixes
-- cli: address PR review feedback and document context inference ([ebd1c35](https://github.com/vriesdemichael/bitbucket-server-cli/commit/ebd1c35efd490f3b40fb1067dd9f316cd8010bea))
-- quality-report: align patch coverage with line-level overlap semantics ([e093e7b](https://github.com/vriesdemichael/bitbucket-server-cli/commit/e093e7b57b3c553f1f6a0b0e6d0bdce0b4e10465))
-- config: bound dotenv lookup and harden bulk/live assertions ([f417f27](https://github.com/vriesdemichael/bitbucket-server-cli/commit/f417f270bc86e68f2f07db1bb84a9800d0291b87))
-- diagnostics: address PR review feedback ([66e80bc](https://github.com/vriesdemichael/bitbucket-server-cli/commit/66e80bc5b09ea81689c8f09d2c6ad43b336cc67f))
-- cli: guard auth command dependencies ([3c3013e](https://github.com/vriesdemichael/bitbucket-server-cli/commit/3c3013e616aa97a793bf909a077c00e24ebf2fbc))
-
-### Docs
-- quality: refresh committed coverage report artifacts ([7178a4d](https://github.com/vriesdemichael/bitbucket-server-cli/commit/7178a4d5d92538e57fddeb594cf4f4f3cf4d70f4))
-- quality: refresh report after strict patch coverage alignment ([bf7f31a](https://github.com/vriesdemichael/bitbucket-server-cli/commit/bf7f31a25f885f508b4014d70ae0265b5bc74b1f))
-- quality: update coverage report for bulk feature ([47188ec](https://github.com/vriesdemichael/bitbucket-server-cli/commit/47188ec0e89940721f695d439978d1c85f7fe569))
-- quality: refresh coverage report after review fixes ([eef5d76](https://github.com/vriesdemichael/bitbucket-server-cli/commit/eef5d76cea9c5fd1642947c10202d6e0cffd9243))
-
-### Tests
-- coverage: raise bulk patch coverage above threshold ([9b5fa0b](https://github.com/vriesdemichael/bitbucket-server-cli/commit/9b5fa0b18fae1266210f0e28df96a91336ee9c54))
-- config: make dotenv tests hermetic ([d21e7d5](https://github.com/vriesdemichael/bitbucket-server-cli/commit/d21e7d589c409f2232428eae37c80773576be7de))
-
-### Chores
-- quality: refresh committed coverage report ([8905912](https://github.com/vriesdemichael/bitbucket-server-cli/commit/89059128458a2bf82808a45412a5cbe8d717bd09))
-- quality: refresh coverage artifacts after auth fix ([d2b166a](https://github.com/vriesdemichael/bitbucket-server-cli/commit/d2b166aeb63a7d29785eced5a55a65a774d30aec))
-- quality: refresh coverage artifacts ([8a389e2](https://github.com/vriesdemichael/bitbucket-server-cli/commit/8a389e2a9bf6c9dad9807a58539fc0a2c781d83b))
-
-## [v0.0.4](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v0.0.4)
-
-Published: 2026-03-06
-
-Changes since v0.0.3.
-
-### Features
-- feat: add search command group for repos, commits, and prs
-- feat(transport): add configurable TLS and retry policy controls
-- feat(test): implement network isolation for unit testing
-- feat(reposettings): implement robust fallback for requiredApprovers payload
-- feat(governance): harden governance commands and standardize error handling
-
-### Fixes
-- fix(codecov): scope default status and keep raw comparator
-- fix(ci): quote workflow step name with colon
-- fix(coverage): address PR review on profile ranges and CI guards
-- fix(test): align ADR with project standards and finalize isolation
-- fix(governance): address remaining PR review comments
-- fix(governance): resolve regressions and satisfy coverage gate
-
-### Docs
-- docs(quality): refresh committed coverage report after linear rebase
-- docs(quality): update coverage report after addressing review comments
-- docs(quality): update coverage report for requiredApprovers fallback
-
-### Tests
-- test(network): add safe transport coverage and refresh report
-
-### CI
-- true
-- ci(coverage): add committed combined codecov profiles and thresholds
-
-### Chores
-- chore(codecov): add components and tighten generated exclusions
-- chore(coverage): refresh committed artifacts for codecov config update
-- chore(coverage): refresh committed coverage artifacts
-- chore(workflow): enforce linear PR history and deterministic rebase flow
-
-## [v0.0.3](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v0.0.3)
-
-Published: 2026-03-05
-
-Changes since v0.0.2.
-
-### Features
-- feat: implement governance commands (permissions, hooks, reviewers, PR settings)
-- feat: implement CLI commands for project, repo, browse, and commit/ref
-- feat(branch): add branch lifecycle and restriction commands
-- feat(pr): implement lifecycle, review, and task operations
-
-### Fixes
-- fix: address PR review comments
-- fix: address PR review on branch restrictions
-- fix(pr): address review feedback on validation and coverage gating
-
-### Tests
-- test(branch): raise coverage to satisfy policy gates
-
-### CI
-- true
-
-### Chores
-- chore: update coverage report artifact
-- chore: refresh coverage report artifact
-- chore(quality): enforce global combined and patch coverage gates
-
-## [v0.0.2](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v0.0.2)
-
-Published: 2026-03-02
-
-Changes since v0.0.1.
-
-### Features
-- feat(release): publish cross-platform binaries with checksums and provenance
-- feat(cli): implement pr list and remove issue placeholder
-
-### Fixes
-- fix(release): address PR review feedback
-- fix: address PR review comments
-
-### Tests
-- test: expand behavior coverage and unify cli setup wiring
-
-### CI
-- true
-
-### Chores
-- chore(quality): refresh committed coverage report
-
-## [v0.0.1](https://github.com/vriesdemichael/bitbucket-server-cli/releases/tag/v0.0.1)
-
-Published: 2026-02-27
-
-Initial release changes.
-
-### Features
-- feat(ci): add GitHub Actions CI and release workflows
-- feat: add tag, build status, and insights commands
-- feat(comment): unify commit and PR comment operations
-- feat: implement issues #1 and #2 repo settings and diff parity
-- feat: establish go-first scaffold with openapi generation and live parity
-
-### CI
-- true
-- ci: add CI Complete aggregate check and explicit unit test job
-
-### Chores
-- chore: restore upstream vendored openapi artifact
-- chore: scaffold live-bitbucket cli repo with migration plan

--- a/scripts/render_docs_changelog.py
+++ b/scripts/render_docs_changelog.py
@@ -56,11 +56,36 @@ def strip_duplicate_heading(tag: str, body: str) -> str:
     return "\n".join(lines).strip()
 
 
+def flatten_body_headings(body: str) -> str:
+    text = body.strip()
+    if not text:
+        return ""
+
+    flattened: list[str] = []
+    heading_pattern = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+
+    for line in text.splitlines():
+        match = heading_pattern.match(line.strip())
+        if not match:
+            flattened.append(line)
+            continue
+
+        label = match.group(2).strip()
+        if not label:
+            continue
+
+        if flattened and flattened[-1].strip():
+            flattened.append("")
+        flattened.append(f"**{label}**")
+
+    return "\n".join(flattened).strip()
+
+
 def render_release(release: dict[str, object]) -> list[str]:
     tag = str(release.get("tag_name") or release.get("name") or "Unversioned release")
     url = str(release.get("html_url") or "").strip()
     published_at = str(release.get("published_at") or "").strip()
-    body = strip_duplicate_heading(tag, str(release.get("body") or ""))
+    body = flatten_body_headings(strip_duplicate_heading(tag, str(release.get("body") or "")))
 
     heading = f"## [{tag}]({url})" if url else f"## {tag}"
     lines = [heading, ""]


### PR DESCRIPTION
## Summary
- update the changelog renderer so release subsection headings no longer appear in the docs page outline
- regenerate the docs changelog so the right-side navigation only lists version numbers
- preserve release section labels inside each version block as bold text instead of headings

## Verification
- gh api repos/vriesdemichael/bitbucket-server-cli/releases > .tmp/releases.json
- python3 scripts/render_docs_changelog.py --releases-json .tmp/releases.json --releases-page-url https://github.com/vriesdemichael/bitbucket-server-cli/releases --output docs/site/changelog.md
- uv run --project docs mkdocs build