### PR TITLE
fix(auth): preserve canonical clone base paths

### DIFF
--- a/docs/quality/coverage-report.json
+++ b/docs/quality/coverage-report.json
@@ -1,15 +1,15 @@
 {
   "version": 2,
   "coverage": {
-    "unit_raw_percent": 18.977955104179262,
-    "unit_scoped_percent": 87.96763445978105,
+    "unit_raw_percent": 18.979970176923384,
+    "unit_scoped_percent": 87.97715373631604,
     "live_raw_percent": 18.798509459988058,
     "live_scoped_percent": 51.0295948663921,
-    "combined_raw_percent": 27.054366662636518,
-    "combined_scoped_percent": 89.91908614945264,
-    "patch_percent": 88.37209302325581,
+    "combined_raw_percent": 27.056381735380647,
+    "combined_scoped_percent": 89.92860542598763,
+    "patch_percent": 100,
     "unit_statements": {
-      "covered": 9418,
+      "covered": 9419,
       "total": 49626
     },
     "live_statements": {
@@ -17,11 +17,11 @@
       "total": 48573
     },
     "combined_statements": {
-      "covered": 13426,
+      "covered": 13427,
       "total": 49626
     },
     "unit_scoped_statements": {
-      "covered": 9241,
+      "covered": 9242,
       "total": 10505
     },
     "live_scoped_statements": {
@@ -29,12 +29,12 @@
       "total": 10441
     },
     "combined_scoped_statements": {
-      "covered": 9446,
+      "covered": 9447,
       "total": 10505
     },
     "patch_lines": {
-      "covered": 38,
-      "total": 43
+      "covered": 2,
+      "total": 2
     },
     "scope": {
       "include_prefixes": [

--- a/docs/quality/coverage.combined.raw.out
+++ b/docs/quality/coverage.combined.raw.out
@@ -3391,7 +3391,7 @@ github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:234.
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:235.1,237.1 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:238.1,238.2 1 0
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:240.1,240.2 1 1
-github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:240.1,242.1 1 0
+github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:240.1,242.1 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:243.1,243.2 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:243.1,245.1 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:246.1,246.2 1 1

--- a/docs/quality/coverage.combined.scoped.out
+++ b/docs/quality/coverage.combined.scoped.out
@@ -3391,7 +3391,7 @@ github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:234.
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:235.1,237.1 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:238.1,238.2 1 0
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:240.1,240.2 1 1
-github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:240.1,242.1 1 0
+github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:240.1,242.1 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:243.1,243.2 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:243.1,245.1 1 1
 github.com/vriesdemichael/bitbucket-server-cli/internal/cli/root_helpers.go:246.1,246.2 1 1

--- a/internal/cli/repo_clone.go
+++ b/internal/cli/repo_clone.go
@@ -278,7 +278,7 @@ func cloneRepositoryWithAuthFallback(
 	if err != nil {
 		return "", err
 	}
-	if hasStoredHTTPAuth && !sameCloneHost(httpCloneURL, resolvedHTTPCloneHost) {
+	if hasStoredHTTPAuth && normalizeHTTPCloneBaseURL(httpCloneURL) != normalizeHTTPCloneBaseURL(resolvedHTTPCloneHost) {
 		httpCloneURL, err = buildBitbucketCloneURL(normalizeHTTPCloneBaseURL(resolvedHTTPCloneHost), repo.ProjectKey, repo.Slug)
 		if err != nil {
 			return "", err
@@ -351,7 +351,7 @@ func resolveCloneHTTPAuth(cfg config.AppConfig, cloneHost string) (config.AppCon
 		return config.AppConfig{}, "", false, nil
 	}
 
-	return storedAuth, cloneHost, true, nil
+	return storedAuth, storedAuth.BitbucketURL, true, nil
 }
 
 func promptForCloneLogin(cmd *cobra.Command, cfg config.AppConfig, cloneHost string, attemptedSSH bool) (config.AppConfig, bool, error) {

--- a/internal/cli/repo_clone_test.go
+++ b/internal/cli/repo_clone_test.go
@@ -302,8 +302,8 @@ func TestResolveCloneHTTPAuthFallbackBranches(t *testing.T) {
 		if !ok || resolved.BitbucketToken != "stored-token" {
 			t.Fatalf("expected stored auth match, got ok=%v cfg=%+v", ok, resolved)
 		}
-		if matchedHost != "https://bitbucket.example.com/scm/PRJ/demo.git" {
-			t.Fatalf("expected direct clone host to be returned, got %q", matchedHost)
+		if matchedHost != "https://bitbucket.example.com" {
+			t.Fatalf("expected canonical stored host to be returned, got %q", matchedHost)
 		}
 	})
 }
@@ -337,6 +337,46 @@ func TestCloneRepositoryWithAuthFallbackUsesCanonicalHostForAliasHTTPSRetry(t *t
 	}
 	if stub.cloneCalls[1].repositoryURL != "https://x-token-auth:stored-token@bitbucket.example.com/context/scm/PRJ/demo.git" {
 		t.Fatalf("expected canonical host https retry, got %s", stub.cloneCalls[1].repositoryURL)
+	}
+}
+
+func TestCloneRepositoryWithAuthFallbackRebuildsHTTPSRetryWhenContextPathDiffers(t *testing.T) {
+	originalFactory := gitBackendFactory
+	stub := &cloneBackendStub{}
+	gitBackendFactory = func() git.Backend { return stub }
+	t.Cleanup(func() { gitBackendFactory = originalFactory })
+
+	configPath := filepath.Join(t.TempDir(), "bb", "config.yaml")
+	t.Setenv("BB_CONFIG_PATH", configPath)
+	t.Setenv("BB_DISABLE_STORED_CONFIG", "")
+	t.Setenv("BITBUCKET_URL", "https://other.example.com")
+	t.Setenv("BITBUCKET_PROJECT_KEY", "PRJ")
+
+	if _, err := config.SaveLogin(config.LoginInput{Host: "https://bitbucket.example.com/context", Token: "stored-token", SetDefault: true}); err != nil {
+		t.Fatalf("save login failed: %v", err)
+	}
+
+	_, err := cloneRepositoryWithAuthFallback(
+		NewRootCommand(),
+		config.AppConfig{BitbucketURL: "https://other.example.com"},
+		"https://bitbucket.example.com/scm/PRJ/demo.git",
+		true,
+		"https://bitbucket.example.com",
+		repositorySelector{ProjectKey: "PRJ", Slug: "demo"},
+		cloneTransportHTTPS,
+		git.CloneOptions{Directory: "demo"},
+		stub,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("clone with auth fallback failed: %v", err)
+	}
+
+	if len(stub.cloneCalls) != 1 {
+		t.Fatalf("expected one https clone attempt, got %d", len(stub.cloneCalls))
+	}
+	if stub.cloneCalls[0].repositoryURL != "https://x-token-auth:stored-token@bitbucket.example.com/context/scm/PRJ/demo.git" {
+		t.Fatalf("expected rebuilt canonical context-path clone url, got %s", stub.cloneCalls[0].repositoryURL)
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix clone HTTP auth fallback so canonical stored Bitbucket base paths are preserved even when the clone host already matches by host
- return the canonical stored Bitbucket URL from stored-auth clone resolution so fallback rebuilds have the correct context path
- add focused regression coverage for host-matched but path-mismatched HTTPS clone fallback

## Context
- follow-up to the post-merge review comment on PR #141

## Validation
- task quality:check