### PR TITLE
fix(release): use computed winget release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -524,6 +524,8 @@ jobs:
         uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: vriesdemichael.bb
+          release-tag: ${{ needs.determine-version.outputs.version }}
+          installers-regex: '^bb_.*_windows_(amd64|arm64)\.zip$'
           token: ${{ secrets.WINGET_TOKEN }}
 
   scoop-release:


### PR DESCRIPTION
## Summary
- fix the WinGet release step to target the computed release tag instead of the branch name
- restrict winget-releaser asset matching to the published Windows zip archives

## Validation
- pre-commit safe Go tests
- pre-push docs validation
- pre-push coverage gate