### PR TITLE
fix(update): accept legacy sigstore bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -494,6 +494,7 @@ jobs:
             fi
             cosign sign-blob \
               --yes \
+              --new-bundle-format \
               --bundle "${file}.sigstore.json" \
               --output-signature "${file}.sig" \
               --output-certificate "${file}.pem" \

--- a/internal/transport/sigstore/verify.go
+++ b/internal/transport/sigstore/verify.go
@@ -3,12 +3,24 @@ package sigstore
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/go-openapi/runtime"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	protorekor "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	sigroot "github.com/sigstore/sigstore-go/pkg/root"
 	sigverify "github.com/sigstore/sigstore-go/pkg/verify"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
 )
 
@@ -39,6 +51,25 @@ type Verifier struct {
 	expectedSAN             string
 	trustedMaterialProvider TrustedMaterialProvider
 	verifierOptions         []sigverify.VerifierOption
+}
+
+type legacyBundlePayload struct {
+	Base64Signature string             `json:"base64Signature"`
+	Cert            string             `json:"cert"`
+	RekorBundle     *legacyRekorBundle `json:"rekorBundle"`
+	Bundle          *legacyRekorBundle `json:"bundle"`
+}
+
+type legacyRekorBundle struct {
+	SignedEntryTimestamp string             `json:"SignedEntryTimestamp"`
+	Payload              legacyRekorPayload `json:"Payload"`
+}
+
+type legacyRekorPayload struct {
+	Body           any   `json:"body"`
+	IntegratedTime int64 `json:"integratedTime"`
+	LogIndex       int64 `json:"logIndex"`
+	LogID          string `json:"logID"`
 }
 
 func NewGitHubReleaseVerifier(owner, repo string) *Verifier {
@@ -94,12 +125,196 @@ func (verifier *Verifier) VerifyBlob(ctx context.Context, artifact, bundleJSON [
 		return Verification{}, apperrors.New(apperrors.KindInternal, "sigstore verifier identity is not configured", nil)
 	}
 
-	var entity bundle.Bundle
-	if err := entity.UnmarshalJSON(bundleJSON); err != nil {
+	entity, err := parseSignedEntity(bundleJSON, artifact)
+	if err != nil {
 		return Verification{}, apperrors.New(apperrors.KindPermanent, "release signature bundle is invalid", err)
 	}
 
-	return verifier.verifyEntity(ctx, &entity, sigverify.WithArtifact(bytes.NewReader(artifact)))
+	return verifier.verifyEntity(ctx, entity, sigverify.WithArtifact(bytes.NewReader(artifact)))
+}
+
+func parseSignedEntity(bundleJSON, artifact []byte) (sigverify.SignedEntity, error) {
+	var entity bundle.Bundle
+	if err := entity.UnmarshalJSON(bundleJSON); err == nil {
+		return &entity, nil
+	} else {
+		legacyEntity, legacyErr := parseLegacyBundle(bundleJSON, artifact)
+		if legacyErr == nil {
+			return legacyEntity, nil
+		}
+		return nil, fmt.Errorf("protobuf bundle parse failed: %v; legacy bundle parse failed: %w", err, legacyErr)
+	}
+}
+
+func parseLegacyBundle(bundleJSON, artifact []byte) (*bundle.Bundle, error) {
+	var legacy legacyBundlePayload
+	if err := json.Unmarshal(bundleJSON, &legacy); err != nil {
+		return nil, err
+	}
+
+	legacyRekor := legacy.RekorBundle
+	if legacyRekor == nil {
+		legacyRekor = legacy.Bundle
+	}
+	if strings.TrimSpace(legacy.Base64Signature) == "" {
+		return nil, fmt.Errorf("missing base64Signature")
+	}
+	if legacyRekor == nil {
+		return nil, fmt.Errorf("missing rekor bundle")
+	}
+
+	signatureBytes, err := base64.StdEncoding.DecodeString(strings.TrimSpace(legacy.Base64Signature))
+	if err != nil {
+		return nil, fmt.Errorf("decoding signature: %w", err)
+	}
+
+	verificationMaterial, err := legacyVerificationMaterial(legacy.Cert)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyBytes, err := legacyBodyBytes(legacyRekor.Payload.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	kindVersion, err := legacyKindVersion(bodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	logID, err := hex.DecodeString(strings.TrimSpace(legacyRekor.Payload.LogID))
+	if err != nil {
+		return nil, fmt.Errorf("decoding rekor log id: %w", err)
+	}
+
+	signedEntryTimestamp, err := base64.StdEncoding.DecodeString(strings.TrimSpace(legacyRekor.SignedEntryTimestamp))
+	if err != nil {
+		return nil, fmt.Errorf("decoding signed entry timestamp: %w", err)
+	}
+
+	mediaType, err := bundle.MediaTypeString("0.1")
+	if err != nil {
+		return nil, fmt.Errorf("building legacy media type: %w", err)
+	}
+
+	digest := sha256.Sum256(artifact)
+	entity, err := bundle.NewBundle(&protobundle.Bundle{
+		MediaType: mediaType,
+		Content: &protobundle.Bundle_MessageSignature{
+			MessageSignature: &protocommon.MessageSignature{
+				MessageDigest: &protocommon.HashOutput{
+					Algorithm: protocommon.HashAlgorithm_SHA2_256,
+					Digest:    digest[:],
+				},
+				Signature: signatureBytes,
+			},
+		},
+		VerificationMaterial: &protobundle.VerificationMaterial{
+			Content: verificationMaterial.Content,
+			TlogEntries: []*protorekor.TransparencyLogEntry{{
+				LogIndex:       legacyRekor.Payload.LogIndex,
+				LogId:          &protocommon.LogId{KeyId: logID},
+				KindVersion:    kindVersion,
+				IntegratedTime: legacyRekor.Payload.IntegratedTime,
+				InclusionPromise: &protorekor.InclusionPromise{
+					SignedEntryTimestamp: signedEntryTimestamp,
+				},
+				CanonicalizedBody: bodyBytes,
+			}},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return entity, nil
+}
+
+func legacyVerificationMaterial(certValue string) (*protobundle.VerificationMaterial, error) {
+	certificates, err := legacyCertificates(certValue)
+	if err != nil {
+		return nil, err
+	}
+	if len(certificates) == 1 {
+		return &protobundle.VerificationMaterial{
+			Content: &protobundle.VerificationMaterial_Certificate{
+				Certificate: &protocommon.X509Certificate{RawBytes: certificates[0].Raw},
+			},
+		}, nil
+	}
+
+	chain := make([]*protocommon.X509Certificate, 0, len(certificates))
+	for _, certificate := range certificates {
+		chain = append(chain, &protocommon.X509Certificate{RawBytes: certificate.Raw})
+	}
+
+	return &protobundle.VerificationMaterial{
+		Content: &protobundle.VerificationMaterial_X509CertificateChain{
+			X509CertificateChain: &protocommon.X509CertificateChain{Certificates: chain},
+		},
+	}, nil
+}
+
+func legacyCertificates(certValue string) ([]*x509.Certificate, error) {
+	trimmed := strings.TrimSpace(certValue)
+	if trimmed == "" {
+		return nil, fmt.Errorf("missing certificate")
+	}
+
+	candidates := [][]byte{[]byte(trimmed)}
+	if decoded, err := base64.StdEncoding.DecodeString(trimmed); err == nil {
+		candidates = append([][]byte{decoded}, candidates...)
+	}
+
+	for _, candidate := range candidates {
+		certificates, err := cryptoutils.UnmarshalCertificatesFromPEM(candidate)
+		if err == nil && len(certificates) > 0 {
+			return certificates, nil
+		}
+		if certificate, parseErr := x509.ParseCertificate(candidate); parseErr == nil {
+			return []*x509.Certificate{certificate}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("legacy bundle certificate is not valid PEM or DER")
+}
+
+func legacyBodyBytes(body any) ([]byte, error) {
+	switch value := body.(type) {
+	case string:
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return nil, fmt.Errorf("missing rekor body")
+		}
+		if decoded, err := base64.StdEncoding.DecodeString(trimmed); err == nil {
+			return decoded, nil
+		}
+		return []byte(trimmed), nil
+	case []byte:
+		if len(value) == 0 {
+			return nil, fmt.Errorf("missing rekor body")
+		}
+		return value, nil
+	default:
+		return nil, fmt.Errorf("unexpected rekor body type %T", body)
+	}
+}
+
+func legacyKindVersion(body []byte) (*protorekor.KindVersion, error) {
+	proposedEntry, err := models.UnmarshalProposedEntry(bytes.NewReader(body), runtime.JSONConsumer())
+	if err != nil {
+		return nil, fmt.Errorf("parsing rekor body: %w", err)
+	}
+	entry, err := types.UnmarshalEntry(proposedEntry)
+	if err != nil {
+		return nil, fmt.Errorf("decoding rekor entry: %w", err)
+	}
+
+	return &protorekor.KindVersion{
+		Kind:    proposedEntry.Kind(),
+		Version: entry.APIVersion(),
+	}, nil
 }
 
 func (verifier *Verifier) verifyEntity(ctx context.Context, entity sigverify.SignedEntity, artifactPolicy sigverify.ArtifactPolicyOption, policyOptions ...sigverify.PolicyOption) (Verification, error) {

--- a/internal/transport/sigstore/verify_test.go
+++ b/internal/transport/sigstore/verify_test.go
@@ -3,7 +3,17 @@ package sigstore
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"reflect"
+	"strings"
 	"testing"
+	"unsafe"
 
 	sigroot "github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
@@ -52,6 +62,229 @@ func TestVerifierVerifyEntity(t *testing.T) {
 	}
 }
 
+func TestVerifierVerifyBlobLegacyBundle(t *testing.T) {
+	artifact, virtualSigstore, _, _, _, legacyJSON := mustLegacyFixture(t)
+	verifier := NewVerifier(Options{
+		ExpectedIssuer: "http://oidc.local:8080",
+		ExpectedSAN:    "foo!oidc.local",
+		TrustedMaterialProvider: func(context.Context) (sigroot.TrustedMaterial, error) {
+			return virtualSigstore, nil
+		},
+		VerifierOptions: []sigverify.VerifierOption{
+			sigverify.WithTransparencyLog(1),
+			sigverify.WithObserverTimestamps(1),
+		},
+	})
+
+	verification, err := verifier.VerifyBlob(context.Background(), artifact, legacyJSON)
+	if err != nil {
+		t.Fatalf("VerifyBlob returned error: %v", err)
+	}
+	if verification.CertificateIdentity != "foo!oidc.local" {
+		t.Fatalf("unexpected certificate identity: %+v", verification)
+	}
+	if verification.CertificateOIDCIssuer != "http://oidc.local:8080" {
+		t.Fatalf("unexpected certificate issuer: %+v", verification)
+	}
+	if verification.TransparencyLogEntriesVerified == 0 {
+		t.Fatalf("expected Rekor verification evidence, got %+v", verification)
+	}
+	if verification.VerifiedTimestampCount == 0 {
+		t.Fatalf("expected verified timestamps, got %+v", verification)
+	}
+}
+
+func TestLegacyVerificationMaterial(t *testing.T) {
+	_, _, _, certificate, _, _ := mustLegacyFixture(t)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw})
+
+	t.Run("single certificate", func(t *testing.T) {
+		material, err := legacyVerificationMaterial(base64.StdEncoding.EncodeToString(pemBytes))
+		if err != nil {
+			t.Fatalf("legacyVerificationMaterial returned error: %v", err)
+		}
+		if material.GetCertificate() == nil {
+			t.Fatal("expected certificate verification material")
+		}
+	})
+
+	t.Run("certificate chain", func(t *testing.T) {
+		material, err := legacyVerificationMaterial(string(append(append([]byte{}, pemBytes...), pemBytes...)))
+		if err != nil {
+			t.Fatalf("legacyVerificationMaterial returned error: %v", err)
+		}
+		chain := material.GetX509CertificateChain()
+		if chain == nil || len(chain.GetCertificates()) != 2 {
+			t.Fatalf("expected two-certificate chain, got %+v", chain)
+		}
+	})
+
+	t.Run("missing certificate", func(t *testing.T) {
+		if _, err := legacyVerificationMaterial(" "); err == nil {
+			t.Fatal("expected error for missing certificate")
+		}
+	})
+
+	t.Run("invalid certificate", func(t *testing.T) {
+		if _, err := legacyVerificationMaterial("not-a-cert"); err == nil {
+			t.Fatal("expected error for invalid certificate")
+		}
+	})
+}
+
+func TestLegacyBodyBytes(t *testing.T) {
+	t.Run("base64 string", func(t *testing.T) {
+		body, err := legacyBodyBytes(base64.StdEncoding.EncodeToString([]byte("hello")))
+		if err != nil {
+			t.Fatalf("legacyBodyBytes returned error: %v", err)
+		}
+		if string(body) != "hello" {
+			t.Fatalf("expected decoded body, got %q", string(body))
+		}
+	})
+
+	t.Run("plain string", func(t *testing.T) {
+		body, err := legacyBodyBytes("{\"kind\":\"hashedrekord\"}")
+		if err != nil {
+			t.Fatalf("legacyBodyBytes returned error: %v", err)
+		}
+		if string(body) != "{\"kind\":\"hashedrekord\"}" {
+			t.Fatalf("unexpected plain string body %q", string(body))
+		}
+	})
+
+	t.Run("bytes", func(t *testing.T) {
+		body, err := legacyBodyBytes([]byte("raw"))
+		if err != nil {
+			t.Fatalf("legacyBodyBytes returned error: %v", err)
+		}
+		if string(body) != "raw" {
+			t.Fatalf("unexpected bytes body %q", string(body))
+		}
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		if _, err := legacyBodyBytes("   "); err == nil {
+			t.Fatal("expected error for empty string body")
+		}
+	})
+
+	t.Run("empty bytes", func(t *testing.T) {
+		if _, err := legacyBodyBytes([]byte{}); err == nil {
+			t.Fatal("expected error for empty byte body")
+		}
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		if _, err := legacyBodyBytes(123); err == nil {
+			t.Fatal("expected error for invalid body type")
+		}
+	})
+}
+
+func TestLegacyKindVersion(t *testing.T) {
+	_, _, _, _, body, _ := mustLegacyFixture(t)
+
+	kindVersion, err := legacyKindVersion(body)
+	if err != nil {
+		t.Fatalf("legacyKindVersion returned error: %v", err)
+	}
+	if kindVersion.Kind == "" || kindVersion.Version == "" {
+		t.Fatalf("expected populated kind/version, got %+v", kindVersion)
+	}
+
+	if _, err := legacyKindVersion([]byte("not-json")); err == nil {
+		t.Fatal("expected error for invalid Rekor body")
+	}
+}
+
+func TestParseLegacyBundleErrors(t *testing.T) {
+	artifact, _, _, _, _, legacyJSON := mustLegacyFixture(t)
+	var legacy map[string]any
+	if err := json.Unmarshal(legacyJSON, &legacy); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+		want   string
+	}{
+		{
+			name: "missing signature",
+			mutate: func(payload map[string]any) {
+				delete(payload, "base64Signature")
+			},
+			want: "missing base64Signature",
+		},
+		{
+			name: "missing rekor bundle",
+			mutate: func(payload map[string]any) {
+				delete(payload, "rekorBundle")
+			},
+			want: "missing rekor bundle",
+		},
+		{
+			name: "invalid signature encoding",
+			mutate: func(payload map[string]any) {
+				payload["base64Signature"] = "%%%"
+			},
+			want: "decoding signature",
+		},
+		{
+			name: "invalid log id",
+			mutate: func(payload map[string]any) {
+				rekorBundle := payload["rekorBundle"].(map[string]any)
+				rekorPayload := rekorBundle["Payload"].(map[string]any)
+				rekorPayload["logID"] = "zz"
+			},
+			want: "decoding rekor log id",
+		},
+		{
+			name: "invalid signed entry timestamp",
+			mutate: func(payload map[string]any) {
+				rekorBundle := payload["rekorBundle"].(map[string]any)
+				rekorBundle["SignedEntryTimestamp"] = "%%%"
+			},
+			want: "decoding signed entry timestamp",
+		},
+		{
+			name: "invalid certificate",
+			mutate: func(payload map[string]any) {
+				payload["cert"] = "%%%"
+			},
+			want: "certificate",
+		},
+		{
+			name: "invalid body type",
+			mutate: func(payload map[string]any) {
+				rekorBundle := payload["rekorBundle"].(map[string]any)
+				rekorPayload := rekorBundle["Payload"].(map[string]any)
+				rekorPayload["body"] = true
+			},
+			want: "unexpected rekor body type",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			payload := cloneLegacyMap(t, legacy)
+			testCase.mutate(payload)
+			mutatedJSON, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("json.Marshal returned error: %v", err)
+			}
+			_, err = parseLegacyBundle(mutatedJSON, artifact)
+			if err == nil {
+				t.Fatal("expected parseLegacyBundle error")
+			}
+			if !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("expected error containing %q, got %v", testCase.want, err)
+			}
+		})
+	}
+}
+
 func TestNewVerifierDefaults(t *testing.T) {
 	verifier := NewVerifier(Options{ExpectedIssuer: " https://issuer.example ", ExpectedSAN: " https://san.example "})
 	if verifier == nil {
@@ -69,6 +302,129 @@ func TestNewVerifierDefaults(t *testing.T) {
 	if len(verifier.verifierOptions) != 3 {
 		t.Fatalf("expected default verifier options, got %d", len(verifier.verifierOptions))
 	}
+}
+
+func marshalLegacyBundle(entity sigverify.SignedEntity) ([]byte, error) {
+	verificationContent, err := entity.VerificationContent()
+	if err != nil {
+		return nil, err
+	}
+	certificate := verificationContent.GetCertificate()
+	if certificate == nil {
+		return nil, errMissingLegacyFixtureComponent("certificate")
+	}
+
+	signatureContent, err := entity.SignatureContent()
+	if err != nil {
+		return nil, err
+	}
+	messageSignature := signatureContent.MessageSignatureContent()
+	if messageSignature == nil {
+		return nil, errMissingLegacyFixtureComponent("message signature")
+	}
+
+	tlogEntries, err := entity.TlogEntries()
+	if err != nil {
+		return nil, err
+	}
+	if len(tlogEntries) == 0 {
+		return nil, errMissingLegacyFixtureComponent("transparency log entry")
+	}
+	signedEntryTimestamp, err := signedEntryTimestampForTest(tlogEntries[0])
+	if err != nil {
+		return nil, err
+	}
+
+	legacy := map[string]any{
+		"base64Signature": base64.StdEncoding.EncodeToString(messageSignature.Signature()),
+		"cert":            base64.StdEncoding.EncodeToString(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw})),
+		"rekorBundle": map[string]any{
+			"SignedEntryTimestamp": base64.StdEncoding.EncodeToString(signedEntryTimestamp),
+			"Payload": map[string]any{
+				"body":           tlogEntries[0].Body(),
+				"integratedTime": tlogEntries[0].IntegratedTime().Unix(),
+				"logIndex":       tlogEntries[0].LogIndex(),
+				"logID":          hex.EncodeToString([]byte(tlogEntries[0].LogKeyID())),
+			},
+		},
+	}
+
+	return json.Marshal(legacy)
+}
+
+func artifactDigest(artifact []byte) []byte {
+	digest := sha256.Sum256(artifact)
+	return digest[:]
+}
+
+func errMissingLegacyFixtureComponent(name string) error {
+	return fmt.Errorf("missing legacy fixture component: %s", name)
+}
+
+func signedEntryTimestampForTest(entry any) ([]byte, error) {
+	value := reflect.ValueOf(entry)
+	if !value.IsValid() || value.IsNil() {
+		return nil, errMissingLegacyFixtureComponent("signed entry timestamp")
+	}
+	entryValue := value.Elem()
+	field := entryValue.FieldByName("signedEntryTimestamp")
+	if !field.IsValid() {
+		return nil, errMissingLegacyFixtureComponent("signed entry timestamp")
+	}
+	return *(*[]byte)(unsafe.Pointer(field.UnsafeAddr())), nil
+}
+
+func mustLegacyFixture(t *testing.T) ([]byte, sigroot.TrustedMaterial, sigverify.SignedEntity, *x509.Certificate, []byte, []byte) {
+	t.Helper()
+	virtualSigstore, err := ca.NewVirtualSigstore()
+	if err != nil {
+		t.Fatalf("NewVirtualSigstore returned error: %v", err)
+	}
+	artifact := []byte("signed checksum manifest")
+	entity, err := virtualSigstore.Sign("foo!oidc.local", "http://oidc.local:8080", artifact)
+	if err != nil {
+		t.Fatalf("Sign returned error: %v", err)
+	}
+	legacyJSON, err := marshalLegacyBundle(entity)
+	if err != nil {
+		t.Fatalf("marshalLegacyBundle returned error: %v", err)
+	}
+
+	verificationContent, err := entity.VerificationContent()
+	if err != nil {
+		t.Fatalf("VerificationContent returned error: %v", err)
+	}
+	certificate := verificationContent.GetCertificate()
+	if certificate == nil {
+		t.Fatal("expected certificate")
+	}
+
+	tlogEntries, err := entity.TlogEntries()
+	if err != nil {
+		t.Fatalf("TlogEntries returned error: %v", err)
+	}
+	if len(tlogEntries) == 0 {
+		t.Fatal("expected Rekor entry")
+	}
+	body, err := legacyBodyBytes(tlogEntries[0].Body())
+	if err != nil {
+		t.Fatalf("legacyBodyBytes returned error: %v", err)
+	}
+
+	return artifact, virtualSigstore, entity, certificate, body, legacyJSON
+}
+
+func cloneLegacyMap(t *testing.T, payload map[string]any) map[string]any {
+	t.Helper()
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	var clone map[string]any
+	if err := json.Unmarshal(encoded, &clone); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	return clone
 }
 
 func TestNewVerifierUsesExplicitProviderAndOptions(t *testing.T) {


### PR DESCRIPTION
## Summary
- accept legacy cosign local bundle JSON in the self-update Sigstore verifier
- emit protobuf Sigstore bundles in the release workflow going forward
- add regression coverage for legacy bundle parsing and error handling

## Validation
- go test ./internal/transport/sigstore ./internal/cli ./internal/workflows/update
- pre-commit safe Go tests via lefthook during commit
- pre-push docs validation and coverage gate passed