### PR TITLE
fix(update): support Bitbucket 10.2.1 and sigstore-go 1.1.4

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -16,7 +16,7 @@ services:
   bitbucket:
     build:
       context: ./custom-bitbucket
-    image: atlassian/bitbucket:9.4.16-faketime
+    image: atlassian/bitbucket:10.2.1-faketime
     container_name: bb-bitbucket
     depends_on:
       - postgres

--- a/docker/custom-bitbucket/Dockerfile
+++ b/docker/custom-bitbucket/Dockerfile
@@ -6,10 +6,24 @@
 FROM ubuntu:24.04 AS faketime-builder
 
 COPY libfaketime-0.9.12.tar.gz /tmp/libfaketime.tar.gz
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
-    && tar -xzf /tmp/libfaketime.tar.gz -C /tmp \
-    && cd /tmp/libfaketime-0.9.12/src \
-    && FAKETIME_COMPILE_CFLAGS="-DFAKE_CLOCK_GETTIME_SYSCALL" make
+RUN set -eu; \
+    attempt=1; \
+    while true; do \
+        rm -rf /var/lib/apt/lists/*; \
+        if apt-get update -o Acquire::Retries=3 \
+            && apt-get install -y --no-install-recommends build-essential; then \
+            break; \
+        fi; \
+        if [ "$attempt" -ge 5 ]; then \
+            exit 1; \
+        fi; \
+        echo "apt-get failed on attempt $attempt; retrying after clearing package lists" >&2; \
+        attempt=$((attempt + 1)); \
+    done; \
+    tar -xzf /tmp/libfaketime.tar.gz -C /tmp; \
+    cd /tmp/libfaketime-0.9.12/src; \
+    FAKETIME_COMPILE_CFLAGS="-DFAKE_CLOCK_GETTIME_SYSCALL" make; \
+    rm -rf /var/lib/apt/lists/*
 
 # Stage 2: final image — only the compiled .so is added, no build tooling.
 FROM atlassian/bitbucket:10.2.1

--- a/docker/custom-bitbucket/Dockerfile
+++ b/docker/custom-bitbucket/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
     && FAKETIME_COMPILE_CFLAGS="-DFAKE_CLOCK_GETTIME_SYSCALL" make
 
 # Stage 2: final image — only the compiled .so is added, no build tooling.
-FROM atlassian/bitbucket:9.4.16
+FROM atlassian/bitbucket:10.2.1
 
 RUN mkdir -p /usr/lib/x86_64-linux-gnu/faketime
 COPY --from=faketime-builder \

--- a/internal/transport/sigstore/verify_test.go
+++ b/internal/transport/sigstore/verify_test.go
@@ -309,7 +309,7 @@ func marshalLegacyBundle(entity sigverify.SignedEntity) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	certificate := verificationContent.GetCertificate()
+	certificate := verificationContentCertificate(verificationContent)
 	if certificate == nil {
 		return nil, errMissingLegacyFixtureComponent("certificate")
 	}
@@ -361,6 +361,23 @@ func errMissingLegacyFixtureComponent(name string) error {
 	return fmt.Errorf("missing legacy fixture component: %s", name)
 }
 
+func verificationContentCertificate(content sigverify.VerificationContent) *x509.Certificate {
+	type certificateProvider interface {
+		Certificate() *x509.Certificate
+	}
+	type legacyCertificateProvider interface {
+		GetCertificate() *x509.Certificate
+	}
+
+	if provider, ok := any(content).(certificateProvider); ok {
+		return provider.Certificate()
+	}
+	if provider, ok := any(content).(legacyCertificateProvider); ok {
+		return provider.GetCertificate()
+	}
+	return nil
+}
+
 func signedEntryTimestampForTest(entry any) ([]byte, error) {
 	value := reflect.ValueOf(entry)
 	if !value.IsValid() || value.IsNil() {
@@ -394,7 +411,7 @@ func mustLegacyFixture(t *testing.T) ([]byte, sigroot.TrustedMaterial, sigverify
 	if err != nil {
 		t.Fatalf("VerificationContent returned error: %v", err)
 	}
-	certificate := verificationContent.GetCertificate()
+	certificate := verificationContentCertificate(verificationContent)
 	if certificate == nil {
 		t.Fatal("expected certificate")
 	}

--- a/scripts/bootstrap-bitbucket.sh
+++ b/scripts/bootstrap-bitbucket.sh
@@ -167,6 +167,46 @@ apply_license_via_rest() {
   exit 1
 }
 
+authenticate_admin_session() {
+  local http_code
+
+  log "Authenticating admin session via TSV login API..."
+  http_code=$(
+    curl -s -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+      -o "$RESPONSE_BODY" -w "%{http_code}" \
+      -X POST "${BASE_URL}/rest/tsv/latest/authenticate" \
+      -H 'Accept: application/json' \
+      -H 'Content-Type: application/json' \
+      -d "{\"username\":\"${ADMIN_USERNAME}\",\"password\":\"${ADMIN_PASSWORD}\",\"targetUrl\":\"/\",\"rememberMe\":false}"
+  )
+  if [[ ! "$http_code" =~ ^20[0-9]$ ]]; then
+    log "Failed to authenticate admin session. HTTP status: ${http_code}. Response body:"
+    cat "$RESPONSE_BODY" >&2
+    exit 1
+  fi
+}
+
+enable_basic_auth() {
+  local http_code
+
+  authenticate_admin_session
+
+  log "Enabling basic authentication for bootstrap-driven admin API calls..."
+  http_code=$(
+    curl -s -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+      -o "$RESPONSE_BODY" -w "%{http_code}" \
+      -X PUT "${BASE_URL}/rest/basicauth/latest/config" \
+      -H 'Accept: application/json' \
+      -H 'Content-Type: application/json' \
+      -d '{"block-requests":false,"allowed-paths":[],"allowed-users":[],"show-warning-message":false}'
+  )
+  if [ "$http_code" != "204" ]; then
+    log "Failed to enable basic authentication. HTTP status: ${http_code}. Response body:"
+    cat "$RESPONSE_BODY" >&2
+    exit 1
+  fi
+}
+
 # Print the Bitbucket server state (STARTING, FIRST_RUN, RUNNING, or empty on
 # error) by querying /status.
 query_state() {
@@ -253,5 +293,7 @@ fi
 if [ "$license_configured_during_setup" != "true" ]; then
   apply_license_via_rest
 fi
+
+enable_basic_auth
 
 log "Bitbucket is RUNNING at ${BASE_URL} (admin user: ${ADMIN_USERNAME})"

--- a/scripts/bootstrap-bitbucket.sh
+++ b/scripts/bootstrap-bitbucket.sh
@@ -8,8 +8,9 @@
 #   2. On FIRST_RUN: walks the setup wizard, handling the licensing/settings
 #      step when present and the admin-user step.
 #   3. Polls /status until RUNNING.
-#   4. If BITBUCKET_LICENSE_KEY is still not consumed by setup, applies it via
-#      the REST API (/rest/api/latest/admin/license).
+#   4. If BITBUCKET_LICENSE_KEY is set and licensing was not completed during
+#      the setup wizard, applies it via the REST API
+#      (/rest/api/latest/admin/license).
 #
 # Usage:
 #   BITBUCKET_LICENSE_KEY=<key> bash scripts/bootstrap-bitbucket.sh [base_url] [username] [password]

--- a/scripts/bootstrap-bitbucket.sh
+++ b/scripts/bootstrap-bitbucket.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # Bootstrap a fresh Bitbucket Data Center instance for CI.
 #
-# The Bitbucket Docker image does NOT auto-apply the license key — it must be
-# applied via the REST API after startup.  This script:
+# The Bitbucket Docker image does NOT auto-apply the license key. Depending on
+# the product version, licensing either happens during the setup wizard or via
+# the REST API after startup. This script:
 #   1. Polls /status until FIRST_RUN or RUNNING.
-#   2. On FIRST_RUN: fetches the setup page for a session cookie and CSRF
-#      token (atl_token), then POSTs the admin-user form.
+#   2. On FIRST_RUN: walks the setup wizard, handling the licensing/settings
+#      step when present and the admin-user step.
 #   3. Polls /status until RUNNING.
-#   4. If BITBUCKET_LICENSE_KEY is set in the environment, applies it via
+#   4. If BITBUCKET_LICENSE_KEY is still not consumed by setup, applies it via
 #      the REST API (/rest/api/latest/admin/license).
 #
 # Usage:
@@ -33,6 +34,137 @@ MAX_WAIT_SECONDS=300
 POLL_INTERVAL=5
 
 log() { echo "[bootstrap-bitbucket] $*" >&2; }
+
+extract_html_input_value() {
+  python3 -c "
+import re, sys
+html = sys.argv[1]
+name = re.escape(sys.argv[2])
+patterns = [
+    rf\"name=['\\\"]{name}['\\\"][^>]*value=['\\\"]([^'\\\"]*)\",
+    rf\"value=['\\\"]([^'\\\"]*)['\\\"][^>]*name=['\\\"]{name}['\\\"]\",
+]
+for pat in patterns:
+    match = re.search(pat, html)
+    if match:
+        print(match.group(1))
+        sys.exit(0)
+sys.exit(1)
+" "$1" "$2"
+}
+
+extract_setup_step() {
+  extract_html_input_value "$1" "step"
+}
+
+submit_setup_settings() {
+  local setup_html="$1"
+  local atl_token application_title setup_base_url http_code response_html response_step
+
+  if [ -z "${BITBUCKET_LICENSE_KEY:-}" ]; then
+    log "Setup requires a license key before admin-user creation, but BITBUCKET_LICENSE_KEY is not set."
+    exit 1
+  fi
+
+  atl_token=$(extract_html_input_value "$setup_html" "atl_token")
+  application_title=$(extract_html_input_value "$setup_html" "applicationTitle" 2>/dev/null || true)
+  setup_base_url=$(extract_html_input_value "$setup_html" "baseUrl" 2>/dev/null || true)
+  : "${application_title:=Bitbucket}"
+  : "${setup_base_url:=${BASE_URL}}"
+
+  log "Submitting licensing and settings step..."
+  http_code=$(
+    curl -s -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+      -o "$RESPONSE_BODY" -w "%{http_code}" \
+      -X POST "${BASE_URL}/setup" \
+      --data-urlencode "step=settings" \
+      --data-urlencode "applicationTitle=${application_title}" \
+      --data-urlencode "baseUrl=${setup_base_url}" \
+      --data-urlencode "license-type=true" \
+      --data-urlencode "license=${BITBUCKET_LICENSE_KEY}" \
+      --data-urlencode "licenseDisplay=${BITBUCKET_LICENSE_KEY}" \
+      --data-urlencode "atl_token=${atl_token}"
+  )
+  log "Settings POST HTTP status: ${http_code}"
+  if [[ ! "$http_code" =~ ^(2[0-9]{2}|302)$ ]]; then
+    log "Unexpected HTTP status ${http_code}. Response body:"
+    cat "$RESPONSE_BODY" >&2
+    exit 1
+  fi
+
+  response_html=$(<"$RESPONSE_BODY")
+  response_step=$(extract_setup_step "$response_html" 2>/dev/null || true)
+  if [ "$http_code" = "200" ] && [ "$response_step" = "settings" ]; then
+    log "Setup settings submission did not advance. Response body:"
+    cat "$RESPONSE_BODY" >&2
+    exit 1
+  fi
+}
+
+submit_setup_user() {
+  local setup_html="$1"
+  local atl_token http_code response_html response_step
+
+  atl_token=$(extract_html_input_value "$setup_html" "atl_token")
+
+  log "Creating admin user '${ADMIN_USERNAME}'..."
+  http_code=$(
+    curl -s -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+      -o "$RESPONSE_BODY" -w "%{http_code}" \
+      -X POST "${BASE_URL}/setup" \
+      --data-urlencode "step=user" \
+      --data-urlencode "username=${ADMIN_USERNAME}" \
+      --data-urlencode "fullname=${ADMIN_DISPLAY_NAME}" \
+      --data-urlencode "email=${ADMIN_EMAIL}" \
+      --data-urlencode "password=${ADMIN_PASSWORD}" \
+      --data-urlencode "confirmPassword=${ADMIN_PASSWORD}" \
+      --data-urlencode "skipJira=" \
+      --data-urlencode "atl_token=${atl_token}"
+  )
+  log "Setup POST HTTP status: ${http_code}"
+  if [[ ! "$http_code" =~ ^(2[0-9]{2}|302)$ ]]; then
+    log "Unexpected HTTP status ${http_code}. Response body:"
+    cat "$RESPONSE_BODY" >&2
+    exit 1
+  fi
+
+  response_html=$(<"$RESPONSE_BODY")
+  response_step=$(extract_setup_step "$response_html" 2>/dev/null || true)
+  if [ "$http_code" = "200" ] && [ "$response_step" = "user" ]; then
+    log "Setup user submission did not advance. Response body:"
+    cat "$RESPONSE_BODY" >&2
+    exit 1
+  fi
+}
+
+apply_license_via_rest() {
+  local license_response
+
+  if [ -z "${BITBUCKET_LICENSE_KEY:-}" ]; then
+    log "BITBUCKET_LICENSE_KEY not set; skipping license application."
+    return 0
+  fi
+
+  log "Applying license key via REST API..."
+  license_response=$(curl -sf -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+    -X POST "${BASE_URL}/rest/api/latest/admin/license" \
+    -H 'Content-Type: application/json' \
+    -d "{\"license\": \"${BITBUCKET_LICENSE_KEY}\"}" 2>&1) && {
+    log "License applied."
+    return 0
+  }
+
+  license_response=$(curl -sf -u "${ADMIN_USERNAME}:${ADMIN_PASSWORD}" \
+    -X POST "${BASE_URL}/rest/api/latest/admin/license" \
+    -H 'Content-Type: application/json' \
+    -d "{\"license\": \"${BITBUCKET_LICENSE_KEY}\"}" 2>&1) && {
+    log "License applied."
+    return 0
+  }
+
+  log "Failed to apply license. Response: ${license_response}"
+  exit 1
+}
 
 # Print the Bitbucket server state (STARTING, FIRST_RUN, RUNNING, or empty on
 # error) by querying /status.
@@ -73,62 +205,52 @@ wait_for_states() {
 
 log "Waiting for Bitbucket to be ready (${BASE_URL})..."
 current_state=$(wait_for_states "FIRST_RUN" "RUNNING")
+license_configured_during_setup=false
 
 if [ "$current_state" = "FIRST_RUN" ]; then
-  log "Fetching setup page to obtain session cookie and CSRF token..."
-  setup_html=$(curl -sf -c "$COOKIE_JAR" "${BASE_URL}/setup" 2>/dev/null)
+  while true; do
+    current_state=$(query_state)
+    if [ "$current_state" = "RUNNING" ]; then
+      break
+    fi
+    if [ "$current_state" != "FIRST_RUN" ]; then
+      current_state=$(wait_for_states "FIRST_RUN" "RUNNING")
+      if [ "$current_state" = "RUNNING" ]; then
+        break
+      fi
+    fi
 
-  atl_token=$(python3 -c "
-import sys, re
-html = sys.argv[1]
-# atl_token appears as either name=...value=... or value=...name=...
-for pat in [r\"name=['\\\"]atl_token['\\\"][^>]*value=['\\\"]([^'\\\"]*)\",
-            r\"value=['\\\"]([^'\\\"]*)['\\\"][^>]*name=['\\\"]atl_token['\\\"]\"]:
-    m = re.search(pat, html)
-    if m:
-        print(m.group(1))
-        sys.exit(0)
-sys.exit(1)
-" "$setup_html")
-  log "Got CSRF token."
+    log "Fetching setup page..."
+    setup_html=$(curl -sf -b "$COOKIE_JAR" -c "$COOKIE_JAR" "${BASE_URL}/setup" 2>/dev/null)
+    setup_step=$(extract_setup_step "$setup_html" 2>/dev/null || true)
 
-  log "Creating admin user '${ADMIN_USERNAME}'..."
-  http_code=$(
-    curl -s -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
-      -o "$RESPONSE_BODY" -w "%{http_code}" \
-      -X POST "${BASE_URL}/setup" \
-      --data-urlencode "step=user" \
-      --data-urlencode "username=${ADMIN_USERNAME}" \
-      --data-urlencode "fullname=${ADMIN_DISPLAY_NAME}" \
-      --data-urlencode "email=${ADMIN_EMAIL}" \
-      --data-urlencode "password=${ADMIN_PASSWORD}" \
-      --data-urlencode "confirmPassword=${ADMIN_PASSWORD}" \
-      --data-urlencode "skipJira=" \
-      --data-urlencode "atl_token=${atl_token}"
-  )
-  log "Setup POST HTTP status: ${http_code}"
-  if [[ ! "$http_code" =~ ^(2[0-9]{2}|302)$ ]]; then
-    log "Unexpected HTTP status ${http_code}. Response body:"
-    cat "$RESPONSE_BODY" >&2
-    exit 1
-  fi
+    case "$setup_step" in
+      settings)
+        submit_setup_settings "$setup_html"
+        license_configured_during_setup=true
+        ;;
+      user)
+        submit_setup_user "$setup_html"
+        ;;
+      "")
+        log "Could not determine setup step from setup page. Response body:"
+        printf '%s\n' "$setup_html" >&2
+        exit 1
+        ;;
+      *)
+        log "Unsupported setup step '${setup_step}'. Response body:"
+        printf '%s\n' "$setup_html" >&2
+        exit 1
+        ;;
+    esac
+  done
 
   log "Waiting for Bitbucket to reach RUNNING state..."
   wait_for_states "RUNNING"
 fi
 
-if [ -n "${BITBUCKET_LICENSE_KEY:-}" ]; then
-  log "Applying license key via REST API..."
-  license_response=$(curl -sf -u "${ADMIN_USERNAME}:${ADMIN_PASSWORD}" \
-    -X POST "${BASE_URL}/rest/api/latest/admin/license" \
-    -H 'Content-Type: application/json' \
-    -d "{\"license\": \"${BITBUCKET_LICENSE_KEY}\"}" 2>&1) || {
-    log "Failed to apply license. Response: ${license_response}"
-    exit 1
-  }
-  log "License applied."
-else
-  log "BITBUCKET_LICENSE_KEY not set; skipping license application."
+if [ "$license_configured_during_setup" != "true" ]; then
+  apply_license_via_rest
 fi
 
 log "Bitbucket is RUNNING at ${BASE_URL} (admin user: ${ADMIN_USERNAME})"


### PR DESCRIPTION
## Summary
- update the local faketime Bitbucket image from 9.4.16 to 10.2.1, which is the latest version compatible with the available evaluation license
- teach the bootstrap script to handle the Bitbucket 10.x setup wizard, including the settings and license step before admin-user creation
- make the sigstore verification test helper work with both legacy `GetCertificate()` and newer `Certificate()` accessors

## Validation
- `task test:unit`
- `env -u BITBUCKET_TOKEN ADMIN_USER=admin ADMIN_PASSWORD=admin BITBUCKET_URL=http://localhost:7990 BB_DISABLE_STORED_CONFIG=1 task test:live`
- destructive local stack rebuild, bootstrap, and rerun on a fresh Bitbucket 10.2.1 instance

## Notes
- this addresses the breakage behind dependabot PRs #153 and #160
- the earlier live-suite 403 flood was traced to auth environment contamination, not a remaining Bitbucket 10.x incompatibility
