### PR TITLE
chore(dependabot): ignore bitbucket image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,5 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "atlassian/bitbucket"


### PR DESCRIPTION
## Summary
Block Dependabot Docker updates for `atlassian/bitbucket`.

## Why
Newer Bitbucket versions are not supported in this local setup, so these PRs are noise and should stay blocked while leaving other Docker dependency updates enabled.
