### PR TITLE
fix: use POST /participants instead of PUT /participants/{userSlug} for adding reviewers

### DIFF
--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1313,7 +1313,7 @@ func TestPRExtendedLifecycleReviewerAndTaskCommands(t *testing.T) {
 		case request.Method == http.MethodDelete && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/approve":
 			writer.Header().Set("Content-Type", "application/json;charset=UTF-8")
 			_, _ = writer.Write([]byte(`{"id":30,"title":"Feature PR","state":"OPEN","open":true,"closed":false}`))
-		case request.Method == http.MethodPut && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants/reviewer2":
+		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants":
 			writer.Header().Set("Content-Type", "application/json;charset=UTF-8")
 			_, _ = writer.Write([]byte(`{"id":30,"title":"Feature PR","state":"OPEN","open":true,"closed":false}`))
 		case request.Method == http.MethodDelete && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants/reviewer2":

--- a/internal/services/pullrequest/service.go
+++ b/internal/services/pullrequest/service.go
@@ -973,14 +973,20 @@ func (service *Service) updateReviewer(ctx context.Context, repository Repositor
 		return PullRequest{}, apperrors.New(apperrors.KindValidation, "reviewer username is required", nil)
 	}
 
-	path := fmt.Sprintf("%s/%s/participants/%s", pullRequestPath(repository), resolvedID, url.PathEscape(trimmedUsername))
-
 	var response pullRequestValue
 	if add {
-		if err := service.client.PutJSON(ctx, path, nil, map[string]any{}, &response); err != nil {
+		path := fmt.Sprintf("%s/%s/participants", pullRequestPath(repository), resolvedID)
+		payload := map[string]any{
+			"user": map[string]any{
+				"name": trimmedUsername,
+			},
+			"role": "REVIEWER",
+		}
+		if err := service.client.PostJSON(ctx, path, nil, payload, &response); err != nil {
 			return PullRequest{}, err
 		}
 	} else {
+		path := fmt.Sprintf("%s/%s/participants/%s", pullRequestPath(repository), resolvedID, url.PathEscape(trimmedUsername))
 		if err := service.client.DeleteJSON(ctx, path, nil, nil, &response); err != nil {
 			return PullRequest{}, err
 		}

--- a/internal/services/pullrequest/service_test.go
+++ b/internal/services/pullrequest/service_test.go
@@ -201,7 +201,7 @@ func TestPullRequestLifecycleReviewAndTaskOperations(t *testing.T) {
 			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"APPROVED","approved":true,"user":{"name":"reviewer1"}}]}`)
 		case request.Method == http.MethodDelete && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/approve":
 			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1"}}]}`)
-		case request.Method == http.MethodPut && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants/reviewer2":
+		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants":
 			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer2"}}]}`)
 		case request.Method == http.MethodDelete && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants/reviewer2":
 			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[]}`)


### PR DESCRIPTION
## Bug Description

The `pr review reviewer add` command always fails with 403 `"You may only update your own status."` even when authenticated as the PR author or a repo admin.

## Root Cause

The command sends a **PUT** request to the per-user participants endpoint:

```
PUT /rest/api/latest/projects/{project}/repos/{repo}/pull-requests/{prId}/participants/{userSlug}
```

According to the [Bitbucket Server REST API docs](https://docs.atlassian.com/bitbucket-server/rest/latest/#api-api-latest-projects-projectKey-repos-repositorySlug-pull-requests-pullRequestId-participants-userSlug-put), this endpoint **only allows updating your own participant status** (e.g., approving/unapproving). It cannot be used to add another user as a reviewer.

## Expected Behavior

The command should use **POST** on the participants collection endpoint:

```
POST /rest/api/latest/projects/{project}/repos/{repo}/pull-requests/{prId}/participants
```

With body:
```json
{
  "user": { "slug": "someone" },
  "role": "REVIEWER",
  "approved": false
}
```

This endpoint allows the PR author or repo admin to add participants with a specified role.

## Reproduction

```bash
# Authenticate as PR author
bb auth login https://bitbucket.example.com --username author --password ****

# Attempt to add a reviewer
bb pr review reviewer add 42 --user other-user
# → 403: "You may only update your own status."
```

## Environment

- **bb version**: v1.19.2
- **Bitbucket Server**: 9.4.16
- **Auth mode**: basic (username + password) and token — both fail with the same 403
- **OS**: Windows 10
