### PR TITLE
feat(pr): add --reviewers flag to pr create

### DIFF
--- a/docs/site/llms.txt
+++ b/docs/site/llms.txt
@@ -67,6 +67,12 @@ Create a pull request:
 bb pr create --repo MYPROJ/payments --from-ref feature/release-readiness --to-ref main --title "Prepare release readiness" --description "Collect release prep changes"
 ```
 
+Create a pull request with reviewers (repeatable or comma-separated):
+
+```bash
+bb pr create --repo MYPROJ/payments --from-ref feature/release-readiness --to-ref main --title "Prepare release readiness" --reviewers alice,bob
+```
+
 Search for repositories:
 
 ```bash

--- a/docs/site/reference/commands/index.md
+++ b/docs/site/reference/commands/index.md
@@ -2592,9 +2592,17 @@ Create a pull request
 Usage:
   bb pr create [flags]
 
+Examples:
+  # Create a pull request
+  bb pr create --repo PROJ/repo --from-ref feature/x --to-ref main --title "My change"
+
+  # Create a pull request and assign reviewers (repeatable or comma-separated)
+  bb pr create --repo PROJ/repo --from-ref feature/x --to-ref main --title "My change" --reviewers alice,bob
+
 Flags:
       --description string   Pull request description
       --from-ref string      Source branch (name or refs/heads/name)
+      --reviewers strings    Reviewer usernames to add (repeatable or comma-separated, e.g. --reviewers alice,bob)
       --title string         Pull request title
       --to-ref string        Target branch (name or refs/heads/name)
 

--- a/internal/cli/insights_pr_admin_commands.go
+++ b/internal/cli/insights_pr_admin_commands.go
@@ -529,10 +529,14 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 	var createToRef string
 	var createTitle string
 	var createDescription string
-	var createReviewers string
+	var createReviewers []string
 	createCmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a pull request",
+		Example: "  # Create a pull request\n" +
+			"  bb pr create --repo PROJ/repo --from-ref feature/x --to-ref main --title \"My change\"\n\n" +
+			"  # Create a pull request and assign reviewers (repeatable or comma-separated)\n" +
+			"  bb pr create --repo PROJ/repo --from-ref feature/x --to-ref main --title \"My change\" --reviewers alice,bob",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, apiClient, err := loadConfigAndClient()
 			if err != nil {
@@ -578,7 +582,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 					Capability:   capabilityFull,
 					Items: []dryRunItem{{
 						Intent:          "pr.create",
-						Target:          map[string]any{"repository": fmt.Sprintf("%s/%s", repo.ProjectKey, repo.Slug), "from_ref": createFromRef, "to_ref": createToRef, "title": createTitle, "reviewers": parseCLICommaList(createReviewers)},
+						Target:          map[string]any{"repository": fmt.Sprintf("%s/%s", repo.ProjectKey, repo.Slug), "from_ref": createFromRef, "to_ref": createToRef, "title": createTitle, "reviewers": createReviewers},
 						Action:          "create",
 						PredictedAction: predicted,
 						Supported:       true,
@@ -608,7 +612,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 				ToRef:       createToRef,
 				Title:       createTitle,
 				Description: createDescription,
-				Reviewers:   parseCLICommaList(createReviewers),
+				Reviewers:   createReviewers,
 			})
 			if err != nil {
 				return err
@@ -626,7 +630,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 	createCmd.Flags().StringVar(&createToRef, "to-ref", "", "Target branch (name or refs/heads/name)")
 	createCmd.Flags().StringVar(&createTitle, "title", "", "Pull request title")
 	createCmd.Flags().StringVar(&createDescription, "description", "", "Pull request description")
-	createCmd.Flags().StringVar(&createReviewers, "reviewers", "", "Reviewer usernames to add (comma-separated, e.g. --reviewers alice,bob)")
+	createCmd.Flags().StringSliceVar(&createReviewers, "reviewers", nil, "Reviewer usernames to add (repeatable or comma-separated, e.g. --reviewers alice,bob)")
 	_ = createCmd.MarkFlagRequired("from-ref")
 	_ = createCmd.MarkFlagRequired("to-ref")
 	_ = createCmd.MarkFlagRequired("title")
@@ -1844,21 +1848,4 @@ func taskUpdateEquivalent(task pullrequestservice.Task, text string, resolved *b
 	}
 
 	return true
-}
-
-func parseCLICommaList(s string) []string {
-	if s == "" {
-		return nil
-	}
-	parts := strings.Split(s, ",")
-	result := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if trimmed := strings.TrimSpace(p); trimmed != "" {
-			result = append(result, trimmed)
-		}
-	}
-	if len(result) == 0 {
-		return nil
-	}
-	return result
 }

--- a/internal/cli/insights_pr_admin_commands.go
+++ b/internal/cli/insights_pr_admin_commands.go
@@ -529,6 +529,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 	var createToRef string
 	var createTitle string
 	var createDescription string
+	var createReviewers string
 	createCmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a pull request",
@@ -577,7 +578,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 					Capability:   capabilityFull,
 					Items: []dryRunItem{{
 						Intent:          "pr.create",
-						Target:          map[string]any{"repository": fmt.Sprintf("%s/%s", repo.ProjectKey, repo.Slug), "from_ref": createFromRef, "to_ref": createToRef, "title": createTitle},
+						Target:          map[string]any{"repository": fmt.Sprintf("%s/%s", repo.ProjectKey, repo.Slug), "from_ref": createFromRef, "to_ref": createToRef, "title": createTitle, "reviewers": parseCLICommaList(createReviewers)},
 						Action:          "create",
 						PredictedAction: predicted,
 						Supported:       true,
@@ -607,6 +608,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 				ToRef:       createToRef,
 				Title:       createTitle,
 				Description: createDescription,
+				Reviewers:   parseCLICommaList(createReviewers),
 			})
 			if err != nil {
 				return err
@@ -624,6 +626,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 	createCmd.Flags().StringVar(&createToRef, "to-ref", "", "Target branch (name or refs/heads/name)")
 	createCmd.Flags().StringVar(&createTitle, "title", "", "Pull request title")
 	createCmd.Flags().StringVar(&createDescription, "description", "", "Pull request description")
+	createCmd.Flags().StringVar(&createReviewers, "reviewers", "", "Reviewer usernames to add (comma-separated, e.g. --reviewers alice,bob)")
 	_ = createCmd.MarkFlagRequired("from-ref")
 	_ = createCmd.MarkFlagRequired("to-ref")
 	_ = createCmd.MarkFlagRequired("title")
@@ -1841,4 +1844,21 @@ func taskUpdateEquivalent(task pullrequestservice.Task, text string, resolved *b
 	}
 
 	return true
+}
+
+func parseCLICommaList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }

--- a/internal/mcp/tools_pr.go
+++ b/internal/mcp/tools_pr.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -73,6 +74,7 @@ func specCreatePullRequest() Spec {
 		mcpgo.WithString("to_ref", mcpgo.Description("Target branch name; defaults to repository default branch")),
 		mcpgo.WithString("title", mcpgo.Required(), mcpgo.Description("Pull request title")),
 		mcpgo.WithString("description", mcpgo.Description("Pull request description (optional)")),
+		mcpgo.WithString("reviewers", mcpgo.Description("Comma-separated reviewer usernames to add (e.g. alice,bob)")),
 	)
 	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
 		svc := pullrequestservice.NewService(c.HTTP)
@@ -88,6 +90,7 @@ func specCreatePullRequest() Spec {
 					ToRef:       req.GetString("to_ref", ""),
 					Title:       title,
 					Description: req.GetString("description", ""),
+					Reviewers:   parseCommaList(req.GetString("reviewers", "")),
 				},
 			)
 			if err != nil {
@@ -262,4 +265,21 @@ func specMergePullRequest() Spec {
 			return resultJSON(pr)
 		}
 	}}
+}
+
+func parseCommaList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }

--- a/internal/mcp/tools_pr.go
+++ b/internal/mcp/tools_pr.go
@@ -267,6 +267,10 @@ func specMergePullRequest() Spec {
 	}}
 }
 
+// parseCommaList splits a comma-separated string into trimmed, non-empty
+// values, returning nil when the input yields no usable entries. MCP tool
+// arguments arrive as single strings, so this adapts them to the []string
+// inputs the service layer expects (e.g. "alice, bob" -> ["alice", "bob"]).
 func parseCommaList(s string) []string {
 	if s == "" {
 		return nil

--- a/internal/mcp/tools_pr_test.go
+++ b/internal/mcp/tools_pr_test.go
@@ -1,0 +1,30 @@
+package mcp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCommaList(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "empty", input: "", want: nil},
+		{name: "blank only", input: "   ", want: nil},
+		{name: "commas only", input: " , , ", want: nil},
+		{name: "single", input: "alice", want: []string{"alice"}},
+		{name: "multiple", input: "alice,bob", want: []string{"alice", "bob"}},
+		{name: "trims and skips blanks", input: " alice , , bob ,", want: []string{"alice", "bob"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseCommaList(tc.input)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseCommaList(%q) = %#v, want %#v", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/services/pullrequest/service.go
+++ b/internal/services/pullrequest/service.go
@@ -65,10 +65,11 @@ type Reviewer struct {
 }
 
 type CreateInput struct {
-	FromRef     string `json:"from_ref"`
-	ToRef       string `json:"to_ref"`
-	Title       string `json:"title"`
-	Description string `json:"description,omitempty"`
+	FromRef     string   `json:"from_ref"`
+	ToRef       string   `json:"to_ref"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Reviewers   []string `json:"reviewers,omitempty"`
 }
 
 type UpdateInput struct {
@@ -880,6 +881,21 @@ func buildCreatePayload(input CreateInput) (map[string]any, error) {
 
 	if description := strings.TrimSpace(input.Description); description != "" {
 		payload["description"] = description
+	}
+
+	if len(input.Reviewers) > 0 {
+		reviewers := make([]map[string]any, 0, len(input.Reviewers))
+		for _, name := range input.Reviewers {
+			if n := strings.TrimSpace(name); n != "" {
+				reviewers = append(reviewers, map[string]any{
+					"user": map[string]any{"name": n},
+					"role": "REVIEWER",
+				})
+			}
+		}
+		if len(reviewers) > 0 {
+			payload["reviewers"] = reviewers
+		}
 	}
 
 	return payload, nil

--- a/internal/services/pullrequest/service.go
+++ b/internal/services/pullrequest/service.go
@@ -69,7 +69,10 @@ type CreateInput struct {
 	ToRef       string   `json:"to_ref"`
 	Title       string   `json:"title"`
 	Description string   `json:"description,omitempty"`
-	Reviewers   []string `json:"reviewers,omitempty"`
+	// Reviewers lists usernames to add as PR reviewers on creation. Blank and
+	// whitespace-only entries are ignored; an empty result omits reviewers from
+	// the request payload.
+	Reviewers []string `json:"reviewers,omitempty"`
 }
 
 type UpdateInput struct {

--- a/internal/services/pullrequest/service_test.go
+++ b/internal/services/pullrequest/service_test.go
@@ -326,6 +326,49 @@ func TestPullRequestTaskAndUpdateValidation(t *testing.T) {
 	}
 }
 
+func TestCreatePullRequestWithReviewers(t *testing.T) {
+	var receivedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests" {
+			receivedBody = readBody(t, r)
+			_, _ = fmt.Fprint(w, `{"id":42,"title":"Feature","state":"OPEN","open":true,"closed":false,"fromRef":{"displayId":"feature/a"},"toRef":{"displayId":"main"},"reviewers":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"alice"}},{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"bob"}}]}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	t.Setenv("BITBUCKET_URL", server.URL)
+	t.Setenv("BITBUCKET_PROJECT_KEY", "TEST")
+
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	service := NewService(httpclient.NewFromConfig(cfg))
+	created, err := service.Create(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, CreateInput{
+		FromRef:   "feature/a",
+		ToRef:     "main",
+		Title:     "Feature",
+		Reviewers: []string{"alice", "bob"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if created.ID != 42 {
+		t.Fatalf("expected PR ID 42, got %d", created.ID)
+	}
+
+	// Verify the request body included reviewers
+	if !strings.Contains(receivedBody, `"reviewers"`) {
+		t.Fatal("expected request body to contain 'reviewers'")
+	}
+	if !strings.Contains(receivedBody, `"alice"`) || !strings.Contains(receivedBody, `"bob"`) {
+		t.Fatal("expected request body to contain reviewer names")
+	}
+}
+
 func intPtr(value int) *int {
 	return &value
 }
@@ -709,6 +752,75 @@ func TestMapMergeabilityBranches(t *testing.T) {
 	}
 	if mapped.Blockers[0].Summary != "" || mapped.Blockers[0].Detail != "detail only blocker" {
 		t.Fatalf("expected detail-only blocker to be preserved, got %#v", mapped.Blockers[0])
+	}
+}
+
+func TestBuildCreatePayloadWithReviewers(t *testing.T) {
+	payload, err := buildCreatePayload(CreateInput{
+		FromRef:   "feature/my-work",
+		ToRef:     "main",
+		Title:     "My PR",
+		Reviewers: []string{"alice", "bob"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if payload["title"] != "My PR" {
+		t.Fatalf("expected title 'My PR', got %v", payload["title"])
+	}
+
+	reviewers, ok := payload["reviewers"].([]map[string]any)
+	if !ok {
+		t.Fatal("expected reviewers to be []map[string]any")
+	}
+	if len(reviewers) != 2 {
+		t.Fatalf("expected 2 reviewers, got %d", len(reviewers))
+	}
+
+	firstUser := reviewers[0]["user"].(map[string]any)
+	if firstUser["name"] != "alice" {
+		t.Fatalf("expected first reviewer 'alice', got %v", firstUser["name"])
+	}
+	if reviewers[0]["role"] != "REVIEWER" {
+		t.Fatalf("expected role 'REVIEWER', got %v", reviewers[0]["role"])
+	}
+
+	secondUser := reviewers[1]["user"].(map[string]any)
+	if secondUser["name"] != "bob" {
+		t.Fatalf("expected second reviewer 'bob', got %v", secondUser["name"])
+	}
+}
+
+func TestBuildCreatePayloadWithoutReviewers(t *testing.T) {
+	payload, err := buildCreatePayload(CreateInput{
+		FromRef: "feature/my-work",
+		ToRef:   "main",
+		Title:   "My PR",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, exists := payload["reviewers"]; exists {
+		t.Fatal("expected no reviewers key when none provided")
+	}
+}
+
+func TestBuildCreatePayloadWithBlankReviewers(t *testing.T) {
+	payload, err := buildCreatePayload(CreateInput{
+		FromRef:   "feature/my-work",
+		ToRef:     "main",
+		Title:     "My PR",
+		Reviewers: []string{"alice", "", "  ", "bob"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	reviewers := payload["reviewers"].([]map[string]any)
+	if len(reviewers) != 2 {
+		t.Fatalf("expected 2 reviewers (blank entries skipped), got %d", len(reviewers))
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a `--reviewers` flag to `bb pr create`, letting users assign reviewers at creation time across both the CLI and the MCP `create_pull_request` tool.

This is the **feature half** of a split from [#201](https://github.com/vriesdemichael/bitbucket-server-cli/pull/201) (originally by @xiedewei). The PUT→POST reviewer-add **bug fix** stays in #201; this PR carries only the new feature so each PR is single-purpose.

## What's included
- CLI: `--reviewers` flag on `bb pr create` (repeatable or comma-separated), wired through dry-run and create.
- MCP: `reviewers` argument on the `create_pull_request` tool.
- Service: `CreateInput.Reviewers`, attached to the create payload as `REVIEWER` participants.
- Tests for payload building and create-with-reviewers.

## Polish applied on top of the original contribution
- Use cobra `StringSliceVar` (matching the existing `--user`/`--group` flags) instead of a hand-rolled comma parser; removed the duplicated `parseCLICommaList` helper. `buildCreatePayload` remains the single trim/filter point.
- Added a usage example to the `create` command.
- Synced the generated command reference and `llms.txt`; documented reviewer-handling behaviour.
- Dropped stray scaffolding files (`CLAUDE.md`, `docs/superpowers/*`) that were not part of the repo conventions.

## Verification note
Local `task test:unit` / `task docs:verify-generated` could not be run in the authoring environment (no Go toolchain). Relying on CI — please confirm `docs:verify-generated` is green; the command-reference block was hand-synced to match cobra output.

Co-authored-by: 谢德伟 <xiedw@glodon.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)