### PR TITLE
feat(pr): add --draft flag and auto-merge commands

### DIFF
--- a/internal/cli/dryrun.go
+++ b/internal/cli/dryrun.go
@@ -116,6 +116,8 @@ var dryRunProfiles = map[string]dryRunProfile{
 	"pr task create":            {Intent: "pr.task.create", Action: "create", Stateful: true},
 	"pr task update":            {Intent: "pr.task.update", Action: "update", Stateful: true},
 	"pr task delete":            {Intent: "pr.task.delete", Action: "delete", Stateful: true},
+	"pr auto-merge enable":      {Intent: "pr.auto-merge.enable", Action: "update", Stateful: true},
+	"pr auto-merge disable":     {Intent: "pr.auto-merge.disable", Action: "delete", Stateful: true},
 	// reviewer conditions
 	"reviewer condition create": {Intent: "reviewer.condition.create", Action: "create", Stateful: true},
 	"reviewer condition update": {Intent: "reviewer.condition.update", Action: "update", Stateful: true},

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -424,6 +424,8 @@ func TestDryRunPassthroughPathCoverage(t *testing.T) {
 		"pr task create",
 		"pr task update",
 		"pr task delete",
+		"pr auto-merge enable",
+		"pr auto-merge disable",
 		"build status set",
 		"build required create",
 		"build required update",

--- a/internal/cli/insights_pr_admin_commands.go
+++ b/internal/cli/insights_pr_admin_commands.go
@@ -530,11 +530,14 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 	var createTitle string
 	var createDescription string
 	var createReviewers []string
+	var createDraft bool
 	createCmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a pull request",
 		Example: "  # Create a pull request\n" +
 			"  bb pr create --repo PROJ/repo --from-ref feature/x --to-ref main --title \"My change\"\n\n" +
+			"  # Create a draft pull request (Bitbucket DC 8.0+)\n" +
+			"  bb pr create --repo PROJ/repo --from-ref feature/x --to-ref main --title \"My change\" --draft\n\n" +
 			"  # Create a pull request and assign reviewers (repeatable or comma-separated)\n" +
 			"  bb pr create --repo PROJ/repo --from-ref feature/x --to-ref main --title \"My change\" --reviewers alice,bob",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -582,7 +585,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 					Capability:   capabilityFull,
 					Items: []dryRunItem{{
 						Intent:          "pr.create",
-						Target:          map[string]any{"repository": fmt.Sprintf("%s/%s", repo.ProjectKey, repo.Slug), "from_ref": createFromRef, "to_ref": createToRef, "title": createTitle, "reviewers": createReviewers},
+						Target:          map[string]any{"repository": fmt.Sprintf("%s/%s", repo.ProjectKey, repo.Slug), "from_ref": createFromRef, "to_ref": createToRef, "title": createTitle, "reviewers": createReviewers, "draft": createDraft},
 						Action:          "create",
 						PredictedAction: predicted,
 						Supported:       true,
@@ -613,6 +616,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 				Title:       createTitle,
 				Description: createDescription,
 				Reviewers:   createReviewers,
+				Draft:       createDraft,
 			})
 			if err != nil {
 				return err
@@ -631,6 +635,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 	createCmd.Flags().StringVar(&createTitle, "title", "", "Pull request title")
 	createCmd.Flags().StringVar(&createDescription, "description", "", "Pull request description")
 	createCmd.Flags().StringSliceVar(&createReviewers, "reviewers", nil, "Reviewer usernames to add (repeatable or comma-separated, e.g. --reviewers alice,bob)")
+	createCmd.Flags().BoolVar(&createDraft, "draft", false, "Create as a draft pull request (Bitbucket DC 8.0+)")
 	_ = createCmd.MarkFlagRequired("from-ref")
 	_ = createCmd.MarkFlagRequired("to-ref")
 	_ = createCmd.MarkFlagRequired("title")
@@ -639,10 +644,17 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 	var updateTitle string
 	var updateDescription string
 	var updateVersion int
+	var updateDraft bool
 	updateCmd := &cobra.Command{
 		Use:   "update <id>",
 		Short: "Update pull request metadata",
-		Args:  cobra.ExactArgs(1),
+		Example: "  # Update title and description\n" +
+			"  bb pr update 42 --repo PROJ/repo --version 1 --title \"New title\"\n\n" +
+			"  # Mark a draft PR as ready for review\n" +
+			"  bb pr update 42 --repo PROJ/repo --version 1 --draft=false\n\n" +
+			"  # Convert an open PR to draft\n" +
+			"  bb pr update 42 --repo PROJ/repo --version 1 --draft",
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, apiClient, err := loadConfigAndClient()
 			if err != nil {
@@ -652,6 +664,11 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 			repo, err := resolvePullRequestRepositoryReference(repository, cfg)
 			if err != nil {
 				return err
+			}
+
+			var draft *bool
+			if cmd.Flags().Changed("draft") {
+				draft = &updateDraft
 			}
 
 			service := pullrequestservice.NewService(httpclient.NewFromConfig(cfg))
@@ -666,10 +683,12 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 					return err
 				}
 
+				draftChanged := draft != nil && current.Draft != *draft
 				predicted := "update"
 				reason := "pull request metadata will be updated"
 				if strings.EqualFold(strings.TrimSpace(current.Title), strings.TrimSpace(updateTitle)) &&
-					strings.EqualFold(strings.TrimSpace(current.Description), strings.TrimSpace(updateDescription)) {
+					strings.EqualFold(strings.TrimSpace(current.Description), strings.TrimSpace(updateDescription)) &&
+					!draftChanged {
 					predicted = "no-op"
 					reason = "pull request already matches requested metadata"
 				}
@@ -680,7 +699,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 					Capability:   capabilityFull,
 					Items: []dryRunItem{{
 						Intent:          "pr.update",
-						Target:          map[string]any{"repository": fmt.Sprintf("%s/%s", repo.ProjectKey, repo.Slug), "id": args[0], "title": updateTitle, "description": updateDescription, "version": updateVersion},
+						Target:          map[string]any{"repository": fmt.Sprintf("%s/%s", repo.ProjectKey, repo.Slug), "id": args[0], "title": updateTitle, "description": updateDescription, "version": updateVersion, "draft": draft},
 						Action:          "update",
 						PredictedAction: predicted,
 						Supported:       true,
@@ -703,6 +722,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 				Title:       updateTitle,
 				Description: updateDescription,
 				Version:     updateVersion,
+				Draft:       draft,
 			})
 			if err != nil {
 				return err
@@ -719,6 +739,7 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 	updateCmd.Flags().StringVar(&updateTitle, "title", "", "Updated pull request title")
 	updateCmd.Flags().StringVar(&updateDescription, "description", "", "Updated pull request description")
 	updateCmd.Flags().IntVar(&updateVersion, "version", 0, "Expected pull request version")
+	updateCmd.Flags().BoolVar(&updateDraft, "draft", false, "Set draft state: --draft to mark as draft, --draft=false to mark as ready for review")
 	_ = updateCmd.MarkFlagRequired("version")
 	prCmd.AddCommand(updateCmd)
 
@@ -1752,6 +1773,201 @@ func newPRCommand(options *rootOptions) *cobra.Command {
 	}
 	buildCmd.AddCommand(buildStatusCmd)
 	prCmd.AddCommand(buildCmd)
+
+	// pr auto-merge
+	autoMergeCmd := &cobra.Command{
+		Use:   "auto-merge",
+		Short: "Pull request auto-merge commands (Bitbucket DC 8.0+)",
+	}
+
+	autoMergeGetCmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get auto-merge configuration for a pull request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+
+			repo, err := resolvePullRequestRepositoryReference(repository, cfg)
+			if err != nil {
+				return err
+			}
+
+			service := pullrequestservice.NewService(httpclient.NewFromConfig(cfg))
+			autoMerge, err := service.GetAutoMerge(cmd.Context(), repo, args[0])
+			if err != nil {
+				return err
+			}
+
+			if options.JSON {
+				return writeJSON(cmd.OutOrStdout(), map[string]any{"repository": repo, "pull_request_id": args[0], "auto_merge": autoMerge})
+			}
+
+			if !autoMerge.Enabled {
+				fmt.Fprintln(cmd.OutOrStdout(), "Auto-merge: disabled")
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Auto-merge: enabled (strategy=%s)\n", autoMerge.StrategyID)
+			return nil
+		},
+	}
+	autoMergeCmd.AddCommand(autoMergeGetCmd)
+
+	var autoMergeStrategy string
+	autoMergeEnableCmd := &cobra.Command{
+		Use:   "enable <id>",
+		Short: "Enable auto-merge on a pull request",
+		Example: "  # Enable auto-merge with the default strategy (no-ff)\n" +
+			"  bb pr auto-merge enable 42 --repo PROJ/repo\n\n" +
+			"  # Enable auto-merge with a specific strategy\n" +
+			"  bb pr auto-merge enable 42 --repo PROJ/repo --strategy rebase-ff-only",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, apiClient, err := loadConfigAndClient()
+			if err != nil {
+				return err
+			}
+
+			repo, err := resolvePullRequestRepositoryReference(repository, cfg)
+			if err != nil {
+				return err
+			}
+
+			service := pullrequestservice.NewService(httpclient.NewFromConfig(cfg))
+			if options.DryRun {
+				checker := options.permissionCheckerFor(apiClient)
+				if err := checker.CheckRepoPermission(cmd.Context(), repo.ProjectKey, repo.Slug, openapigenerated.REPOWRITE); err != nil {
+					return err
+				}
+
+				current, err := service.GetAutoMerge(cmd.Context(), repo, args[0])
+				if err != nil {
+					return err
+				}
+
+				predicted := "update"
+				reason := "auto-merge will be enabled"
+				if current.Enabled && strings.EqualFold(strings.TrimSpace(current.StrategyID), strings.TrimSpace(autoMergeStrategy)) {
+					predicted = "no-op"
+					reason = "auto-merge is already enabled with the same strategy"
+				}
+
+				preview := dryRunPreview{
+					DryRun:       true,
+					PlanningMode: planningModeStateful,
+					Capability:   capabilityFull,
+					Items: []dryRunItem{{
+						Intent:          "pr.auto-merge.enable",
+						Target:          map[string]any{"repository": fmt.Sprintf("%s/%s", repo.ProjectKey, repo.Slug), "id": args[0], "strategy": autoMergeStrategy},
+						Action:          "update",
+						PredictedAction: predicted,
+						Supported:       true,
+						Reason:          reason,
+						Confidence:      capabilityFull,
+						RequiredState:   []string{"pull request auto-merge"},
+					}},
+					Summary: dryRunSummary{Total: 1, Supported: 1},
+				}
+				if predicted == "update" {
+					preview.Summary.UpdateCount = 1
+				} else {
+					preview.Summary.NoopCount = 1
+				}
+
+				return writeDryRunPreview(cmd.OutOrStdout(), options.JSON, preview)
+			}
+
+			autoMerge, err := service.EnableAutoMerge(cmd.Context(), repo, args[0], autoMergeStrategy)
+			if err != nil {
+				return err
+			}
+
+			if options.JSON {
+				return writeJSON(cmd.OutOrStdout(), map[string]any{"repository": repo, "pull_request_id": args[0], "auto_merge": autoMerge})
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Enabled auto-merge on pull request #%s (strategy=%s)\n", args[0], autoMerge.StrategyID)
+			return nil
+		},
+	}
+	autoMergeEnableCmd.Flags().StringVar(&autoMergeStrategy, "strategy", "no-ff", "Merge strategy: no-ff, ff-only, rebase-no-ff, rebase-ff-only, squash, squash-ff-only")
+	autoMergeCmd.AddCommand(autoMergeEnableCmd)
+
+	autoMergeDisableCmd := &cobra.Command{
+		Use:   "disable <id>",
+		Short: "Disable auto-merge on a pull request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, apiClient, err := loadConfigAndClient()
+			if err != nil {
+				return err
+			}
+
+			repo, err := resolvePullRequestRepositoryReference(repository, cfg)
+			if err != nil {
+				return err
+			}
+
+			service := pullrequestservice.NewService(httpclient.NewFromConfig(cfg))
+			if options.DryRun {
+				checker := options.permissionCheckerFor(apiClient)
+				if err := checker.CheckRepoPermission(cmd.Context(), repo.ProjectKey, repo.Slug, openapigenerated.REPOWRITE); err != nil {
+					return err
+				}
+
+				current, err := service.GetAutoMerge(cmd.Context(), repo, args[0])
+				if err != nil {
+					return err
+				}
+
+				predicted := "delete"
+				reason := "auto-merge will be disabled"
+				if !current.Enabled {
+					predicted = "no-op"
+					reason = "auto-merge is not enabled"
+				}
+
+				preview := dryRunPreview{
+					DryRun:       true,
+					PlanningMode: planningModeStateful,
+					Capability:   capabilityFull,
+					Items: []dryRunItem{{
+						Intent:          "pr.auto-merge.disable",
+						Target:          map[string]any{"repository": fmt.Sprintf("%s/%s", repo.ProjectKey, repo.Slug), "id": args[0]},
+						Action:          "delete",
+						PredictedAction: predicted,
+						Supported:       true,
+						Reason:          reason,
+						Confidence:      capabilityFull,
+						RequiredState:   []string{"pull request auto-merge"},
+					}},
+					Summary: dryRunSummary{Total: 1, Supported: 1},
+				}
+				if predicted == "delete" {
+					preview.Summary.DeleteCount = 1
+				} else {
+					preview.Summary.NoopCount = 1
+				}
+
+				return writeDryRunPreview(cmd.OutOrStdout(), options.JSON, preview)
+			}
+
+			if err := service.DisableAutoMerge(cmd.Context(), repo, args[0]); err != nil {
+				return err
+			}
+
+			if options.JSON {
+				return writeJSON(cmd.OutOrStdout(), map[string]any{"status": "ok", "repository": repo, "pull_request_id": args[0]})
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Disabled auto-merge on pull request #%s\n", args[0])
+			return nil
+		},
+	}
+	autoMergeCmd.AddCommand(autoMergeDisableCmd)
+	prCmd.AddCommand(autoMergeCmd)
 
 	return prCmd
 }

--- a/internal/cli/pr_draft_automerge_test.go
+++ b/internal/cli/pr_draft_automerge_test.go
@@ -1,0 +1,336 @@
+package cli
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newDraftAutoMergeServer returns a mock Bitbucket server covering the endpoints
+// exercised by the draft and auto-merge CLI commands: the permission-filtered
+// repository listing used by dry-run prechecks, pull request reads/writes, and
+// the per-PR auto-merge resource.
+//
+// PR 30 has auto-merge disabled (GET auto-merge → 404) and draft=false.
+// PR 31 has auto-merge enabled with strategy no-ff and draft=true.
+func newDraftAutoMergeServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		switch {
+		// Permission precheck (dry-run): repository list filtered by permission.
+		case r.Method == http.MethodGet && path == "/rest/api/latest/repos":
+			_, _ = w.Write([]byte(`{"values":[{"slug":"demo","name":"demo","project":{"key":"TEST"}}],"isLastPage":true}`))
+
+		// Open PR list used by pr create dry-run conflict detection.
+		case r.Method == http.MethodGet && path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests":
+			_, _ = w.Write([]byte(`{"isLastPage":true,"values":[]}`))
+
+		// Create PR (execution path).
+		case r.Method == http.MethodPost && path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests":
+			body := readRequestBody(t, r)
+			if !strings.Contains(body, `"draft":true`) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"errors":[{"message":"expected draft flag"}]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"id":40,"title":"Draft feature","state":"OPEN","open":true,"closed":false,"draft":true,"fromRef":{"displayId":"feature/x"},"toRef":{"displayId":"master"}}`))
+
+		// PR 30 detail (draft=false, open).
+		case r.Method == http.MethodGet && path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30":
+			_, _ = w.Write([]byte(`{"id":30,"title":"Same","description":"Same desc","state":"OPEN","open":true,"closed":false,"draft":false,"version":1,"fromRef":{"displayId":"feature/x"},"toRef":{"displayId":"master"}}`))
+		// PR 31 detail (draft=true, open).
+		case r.Method == http.MethodGet && path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/31":
+			_, _ = w.Write([]byte(`{"id":31,"title":"Draft","description":"Draft desc","state":"OPEN","open":true,"closed":false,"draft":true,"version":2,"fromRef":{"displayId":"feature/y"},"toRef":{"displayId":"master"}}`))
+
+		// Mergeability lookups are optional; 404 is tolerated by the service layer.
+		case r.Method == http.MethodGet && strings.HasSuffix(path, "/merge"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errors":[{"message":"no mergeability"}]}`))
+
+		// Update PR (execution path).
+		case r.Method == http.MethodPut && path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30":
+			body := readRequestBody(t, r)
+			draftFlag := "false"
+			if strings.Contains(body, `"draft":true`) {
+				draftFlag = "true"
+			}
+			_, _ = w.Write([]byte(`{"id":30,"title":"Same","state":"OPEN","open":true,"closed":false,"draft":` + draftFlag + `,"version":2,"fromRef":{"displayId":"feature/x"},"toRef":{"displayId":"master"}}`))
+
+		// Auto-merge for PR 30: not configured.
+		case path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/auto-merge":
+			switch r.Method {
+			case http.MethodGet:
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"errors":[{"message":"auto-merge not configured"}]}`))
+			case http.MethodPost:
+				body := readRequestBody(t, r)
+				strategy := "no-ff"
+				if strings.Contains(body, "rebase-ff-only") {
+					strategy = "rebase-ff-only"
+				}
+				_, _ = w.Write([]byte(`{"strategyId":"` + strategy + `"}`))
+			default:
+				http.NotFound(w, r)
+			}
+
+		// Auto-merge for PR 31: configured with no-ff.
+		case path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/31/auto-merge":
+			switch r.Method {
+			case http.MethodGet:
+				_, _ = w.Write([]byte(`{"strategyId":"no-ff"}`))
+			case http.MethodDelete:
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				http.NotFound(w, r)
+			}
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func readRequestBody(t *testing.T, r *http.Request) string {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("failed to read request body: %v", err)
+	}
+	return string(body)
+}
+
+func TestPRCreateDraftFlag(t *testing.T) {
+	server := newDraftAutoMergeServer(t)
+	defer server.Close()
+	configureDryRunEnv(t, server.URL, "TEST", "demo")
+
+	// Dry-run: target metadata records the draft intent and predicts create.
+	out, err := executeTestCLI(t, "--json", "--dry-run", "pr", "create", "--from-ref", "feature/x", "--to-ref", "master", "--title", "Draft feature", "--draft")
+	if err != nil {
+		t.Fatalf("unexpected error: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, `"predicted_action": "create"`) {
+		t.Fatalf("expected create prediction, output=%s", out)
+	}
+	if !strings.Contains(out, `"draft": true`) {
+		t.Fatalf("expected draft:true in dry-run target, output=%s", out)
+	}
+
+	// Execution: the POST payload must carry draft:true (asserted by the server).
+	out, err = executeTestCLI(t, "pr", "create", "--from-ref", "feature/x", "--to-ref", "master", "--title", "Draft feature", "--draft")
+	if err != nil {
+		t.Fatalf("unexpected error creating draft PR: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, "Created pull request #40") {
+		t.Fatalf("expected created PR message, output=%s", out)
+	}
+}
+
+func TestPRUpdateDraftToggle(t *testing.T) {
+	server := newDraftAutoMergeServer(t)
+	defer server.Close()
+	configureDryRunEnv(t, server.URL, "TEST", "demo")
+
+	// Dry-run: converting a non-draft PR to draft predicts an update.
+	out, err := executeTestCLI(t, "--json", "--dry-run", "pr", "update", "30", "--version", "1", "--draft")
+	if err != nil {
+		t.Fatalf("unexpected error: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, `"predicted_action": "update"`) {
+		t.Fatalf("expected update prediction when toggling draft on, output=%s", out)
+	}
+
+	// Dry-run: requesting the existing state with matching metadata is a no-op.
+	out, err = executeTestCLI(t, "--json", "--dry-run", "pr", "update", "30", "--version", "1", "--title", "Same", "--description", "Same desc", "--draft=false")
+	if err != nil {
+		t.Fatalf("unexpected error: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, `"predicted_action": "no-op"`) {
+		t.Fatalf("expected no-op prediction when draft already matches, output=%s", out)
+	}
+
+	// Execution: mark the PR ready for review (draft=false).
+	out, err = executeTestCLI(t, "pr", "update", "30", "--version", "1", "--draft=false")
+	if err != nil {
+		t.Fatalf("unexpected error updating draft state: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, "Updated pull request #30") {
+		t.Fatalf("expected updated PR message, output=%s", out)
+	}
+}
+
+func TestPRAutoMergeGet(t *testing.T) {
+	server := newDraftAutoMergeServer(t)
+	defer server.Close()
+	configureDryRunEnv(t, server.URL, "TEST", "demo")
+
+	// PR 30: auto-merge disabled.
+	out, err := executeTestCLI(t, "pr", "auto-merge", "get", "30")
+	if err != nil {
+		t.Fatalf("unexpected error: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, "Auto-merge: disabled") {
+		t.Fatalf("expected disabled output, got=%s", out)
+	}
+
+	// PR 31: auto-merge enabled with no-ff.
+	out, err = executeTestCLI(t, "pr", "auto-merge", "get", "31")
+	if err != nil {
+		t.Fatalf("unexpected error: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, "Auto-merge: enabled") || !strings.Contains(out, "no-ff") {
+		t.Fatalf("expected enabled no-ff output, got=%s", out)
+	}
+
+	// JSON output path.
+	out, err = executeTestCLI(t, "--json", "pr", "auto-merge", "get", "31")
+	if err != nil {
+		t.Fatalf("unexpected error: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, `"enabled": true`) {
+		t.Fatalf("expected enabled:true in JSON, got=%s", out)
+	}
+}
+
+func TestPRAutoMergeEnable(t *testing.T) {
+	server := newDraftAutoMergeServer(t)
+	defer server.Close()
+	configureDryRunEnv(t, server.URL, "TEST", "demo")
+
+	// Dry-run: enabling on a PR without auto-merge predicts an update.
+	out, err := executeTestCLI(t, "--json", "--dry-run", "pr", "auto-merge", "enable", "30", "--strategy", "rebase-ff-only")
+	if err != nil {
+		t.Fatalf("unexpected error: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, `"predicted_action": "update"`) {
+		t.Fatalf("expected update prediction enabling auto-merge, output=%s", out)
+	}
+
+	// Dry-run: enabling with the same strategy already set is a no-op.
+	out, err = executeTestCLI(t, "--json", "--dry-run", "pr", "auto-merge", "enable", "31", "--strategy", "no-ff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, `"predicted_action": "no-op"`) {
+		t.Fatalf("expected no-op prediction for unchanged strategy, output=%s", out)
+	}
+
+	// Execution: enable auto-merge with an explicit strategy.
+	out, err = executeTestCLI(t, "pr", "auto-merge", "enable", "30", "--strategy", "rebase-ff-only")
+	if err != nil {
+		t.Fatalf("unexpected error enabling auto-merge: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, "Enabled auto-merge on pull request #30") || !strings.Contains(out, "rebase-ff-only") {
+		t.Fatalf("expected enable confirmation, output=%s", out)
+	}
+
+	// Execution (JSON): the auto_merge object is emitted as a machine envelope.
+	out, err = executeTestCLI(t, "--json", "pr", "auto-merge", "enable", "30", "--strategy", "rebase-ff-only")
+	if err != nil {
+		t.Fatalf("unexpected error enabling auto-merge (json): %v output=%s", err, out)
+	}
+	if !strings.Contains(out, `"enabled": true`) {
+		t.Fatalf("expected enabled:true in JSON enable output, got=%s", out)
+	}
+}
+
+func TestPRAutoMergeDisable(t *testing.T) {
+	server := newDraftAutoMergeServer(t)
+	defer server.Close()
+	configureDryRunEnv(t, server.URL, "TEST", "demo")
+
+	// Dry-run: disabling a configured PR predicts a delete.
+	out, err := executeTestCLI(t, "--json", "--dry-run", "pr", "auto-merge", "disable", "31")
+	if err != nil {
+		t.Fatalf("unexpected error: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, `"predicted_action": "delete"`) {
+		t.Fatalf("expected delete prediction disabling auto-merge, output=%s", out)
+	}
+
+	// Dry-run: disabling a PR without auto-merge is a no-op.
+	out, err = executeTestCLI(t, "--json", "--dry-run", "pr", "auto-merge", "disable", "30")
+	if err != nil {
+		t.Fatalf("unexpected error: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, `"predicted_action": "no-op"`) {
+		t.Fatalf("expected no-op prediction for unconfigured auto-merge, output=%s", out)
+	}
+
+	// Execution: disable auto-merge.
+	out, err = executeTestCLI(t, "pr", "auto-merge", "disable", "31")
+	if err != nil {
+		t.Fatalf("unexpected error disabling auto-merge: %v output=%s", err, out)
+	}
+	if !strings.Contains(out, "Disabled auto-merge on pull request #31") {
+		t.Fatalf("expected disable confirmation, output=%s", out)
+	}
+
+	// Execution (JSON): emits an ok status envelope.
+	out, err = executeTestCLI(t, "--json", "pr", "auto-merge", "disable", "31")
+	if err != nil {
+		t.Fatalf("unexpected error disabling auto-merge (json): %v output=%s", err, out)
+	}
+	if !strings.Contains(out, `"status": "ok"`) {
+		t.Fatalf("expected ok status in JSON disable output, got=%s", out)
+	}
+}
+
+// TestPRAutoMergeErrorPaths exercises the error-return branches of the
+// auto-merge commands: invalid pull request IDs (service validation errors in
+// both execution and dry-run paths) and a failing permission precheck.
+func TestPRAutoMergeErrorPaths(t *testing.T) {
+	server := newDraftAutoMergeServer(t)
+	defer server.Close()
+	configureDryRunEnv(t, server.URL, "TEST", "demo")
+
+	// Execution paths: a non-numeric ID fails service-layer ID validation.
+	for _, sub := range [][]string{
+		{"pr", "auto-merge", "get", "not-a-number"},
+		{"pr", "auto-merge", "enable", "not-a-number"},
+		{"pr", "auto-merge", "disable", "not-a-number"},
+	} {
+		if _, err := executeTestCLI(t, sub...); err == nil {
+			t.Fatalf("expected validation error for %v", sub)
+		}
+	}
+
+	// Dry-run paths: permission precheck passes, then GetAutoMerge rejects the ID.
+	for _, sub := range [][]string{
+		{"--dry-run", "pr", "auto-merge", "enable", "not-a-number"},
+		{"--dry-run", "pr", "auto-merge", "disable", "not-a-number"},
+	} {
+		if _, err := executeTestCLI(t, sub...); err == nil {
+			t.Fatalf("expected dry-run validation error for %v", sub)
+		}
+	}
+}
+
+// TestPRAutoMergeDryRunPermissionFailure verifies the dry-run permission
+// precheck error branch: when the caller lacks REPO_WRITE the command fails
+// before any auto-merge prediction.
+func TestPRAutoMergeDryRunPermissionFailure(t *testing.T) {
+	// Server returns an empty permission-filtered repo list, so the precheck
+	// concludes the caller lacks the required permission.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/rest/api/latest/repos" {
+			_, _ = w.Write([]byte(`{"values":[],"isLastPage":true}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+	configureDryRunEnv(t, server.URL, "TEST", "demo")
+
+	if _, err := executeTestCLI(t, "--dry-run", "pr", "auto-merge", "enable", "30"); err == nil {
+		t.Fatal("expected permission precheck failure for auto-merge enable dry-run")
+	}
+	if _, err := executeTestCLI(t, "--dry-run", "pr", "auto-merge", "disable", "30"); err == nil {
+		t.Fatal("expected permission precheck failure for auto-merge disable dry-run")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -61,6 +61,10 @@ func AllSpecs() []Spec {
 		{specSubmitPRReview().Tool, specSubmitPRReview().Handler, true},
 		// Merging is irreversible and affects the target branch — requires --yolo.
 		{specMergePullRequest().Tool, specMergePullRequest().Handler, false},
+		// Enabling auto-merge can trigger an irreversible merge — requires --yolo.
+		{specEnableAutoMerge().Tool, specEnableAutoMerge().Handler, false},
+		// Disabling auto-merge stops automation — safe (easily re-enabled).
+		{specDisableAutoMerge().Tool, specDisableAutoMerge().Handler, true},
 		// Repository group
 		{specSearchRepositories().Tool, specSearchRepositories().Handler, true},
 		{specGetRepositoryCloneInfo().Tool, specGetRepositoryCloneInfo().Handler, true},

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -41,7 +41,7 @@ func testClients(t *testing.T) Clients {
 
 // TestAllSpecsReturnsExpectedCount ensures the catalog has exactly the expected number of tools.
 func TestAllSpecsReturnsExpectedCount(t *testing.T) {
-	const wantCount = 20
+	const wantCount = 22
 	specs := AllSpecs()
 	if len(specs) != wantCount {
 		t.Errorf("AllSpecs: got %d tools, want %d", len(specs), wantCount)
@@ -258,6 +258,8 @@ func TestToolNamesMatchExpected(t *testing.T) {
 		"list_pr_tasks",
 		"submit_pr_review",
 		"merge_pull_request",
+		"enable_auto_merge",
+		"disable_auto_merge",
 		"search_repositories",
 		"get_repository_clone_info",
 		"list_branches",

--- a/internal/mcp/tools_pr.go
+++ b/internal/mcp/tools_pr.go
@@ -75,6 +75,7 @@ func specCreatePullRequest() Spec {
 		mcpgo.WithString("title", mcpgo.Required(), mcpgo.Description("Pull request title")),
 		mcpgo.WithString("description", mcpgo.Description("Pull request description (optional)")),
 		mcpgo.WithString("reviewers", mcpgo.Description("Comma-separated reviewer usernames to add (e.g. alice,bob)")),
+		mcpgo.WithBoolean("draft", mcpgo.Description("Create as a draft pull request (Bitbucket DC 8.0+; default false)")),
 	)
 	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
 		svc := pullrequestservice.NewService(c.HTTP)
@@ -91,6 +92,7 @@ func specCreatePullRequest() Spec {
 					Title:       title,
 					Description: req.GetString("description", ""),
 					Reviewers:   parseCommaList(req.GetString("reviewers", "")),
+					Draft:       req.GetBool("draft", false),
 				},
 			)
 			if err != nil {
@@ -263,6 +265,56 @@ func specMergePullRequest() Spec {
 				return mcpgo.NewToolResultErrorFromErr("merge_pull_request failed", err), nil
 			}
 			return resultJSON(pr)
+		}
+	}}
+}
+
+func specEnableAutoMerge() Spec {
+	tool := mcpgo.NewTool("enable_auto_merge",
+		mcpgo.WithDescription("Enable auto-merge on a pull request. The PR will be merged automatically once all required checks pass and reviewers have approved. Requires Bitbucket DC 8.0+."),
+		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
+		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
+		mcpgo.WithString("pr_id", mcpgo.Required(), mcpgo.Description("Pull request ID")),
+		mcpgo.WithString("strategy", mcpgo.Description("Merge strategy: no-ff (default), ff-only, rebase-no-ff, rebase-ff-only, squash, squash-ff-only"),
+			mcpgo.Enum("no-ff", "ff-only", "rebase-no-ff", "rebase-ff-only", "squash", "squash-ff-only")),
+	)
+	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
+		svc := pullrequestservice.NewService(c.HTTP)
+		return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			project, _ := req.RequireString("project")
+			repo, _ := req.RequireString("repo")
+			prID, _ := req.RequireString("pr_id")
+			strategy := req.GetString("strategy", "no-ff")
+			autoMerge, err := svc.EnableAutoMerge(ctx,
+				pullrequestservice.RepositoryRef{ProjectKey: project, Slug: repo},
+				prID,
+				strategy,
+			)
+			if err != nil {
+				return mcpgo.NewToolResultErrorFromErr("enable_auto_merge failed", err), nil
+			}
+			return resultJSON(autoMerge)
+		}
+	}}
+}
+
+func specDisableAutoMerge() Spec {
+	tool := mcpgo.NewTool("disable_auto_merge",
+		mcpgo.WithDescription("Disable auto-merge on a pull request. The PR will no longer be merged automatically."),
+		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
+		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
+		mcpgo.WithString("pr_id", mcpgo.Required(), mcpgo.Description("Pull request ID")),
+	)
+	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
+		svc := pullrequestservice.NewService(c.HTTP)
+		return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			project, _ := req.RequireString("project")
+			repo, _ := req.RequireString("repo")
+			prID, _ := req.RequireString("pr_id")
+			if err := svc.DisableAutoMerge(ctx, pullrequestservice.RepositoryRef{ProjectKey: project, Slug: repo}, prID); err != nil {
+				return mcpgo.NewToolResultErrorFromErr("disable_auto_merge failed", err), nil
+			}
+			return resultJSON(map[string]any{"status": "ok", "auto_merge": map[string]any{"enabled": false}})
 		}
 	}}
 }

--- a/internal/services/pullrequest/service.go
+++ b/internal/services/pullrequest/service.go
@@ -31,6 +31,7 @@ type PullRequest struct {
 	State        string         `json:"state"`
 	Open         bool           `json:"open"`
 	Closed       bool           `json:"closed"`
+	Draft        bool           `json:"draft,omitempty"`
 	Repository   *RepositoryRef `json:"repository,omitempty"`
 	Version      int            `json:"version,omitempty"`
 	Author       string         `json:"author,omitempty"`
@@ -69,6 +70,7 @@ type CreateInput struct {
 	ToRef       string   `json:"to_ref"`
 	Title       string   `json:"title"`
 	Description string   `json:"description,omitempty"`
+	Draft       bool     `json:"draft,omitempty"`
 	// Reviewers lists usernames to add as PR reviewers on creation. Blank and
 	// whitespace-only entries are ignored; an empty result omits reviewers from
 	// the request payload.
@@ -79,6 +81,15 @@ type UpdateInput struct {
 	Title       string `json:"title,omitempty"`
 	Description string `json:"description,omitempty"`
 	Version     int    `json:"version"`
+	// Draft, when non-nil, sets or clears the draft flag on the pull request.
+	Draft *bool `json:"draft,omitempty"`
+}
+
+// AutoMerge represents the auto-merge configuration for a pull request.
+// Enabled is false when no auto-merge is configured (the API returns 404).
+type AutoMerge struct {
+	Enabled    bool   `json:"enabled"`
+	StrategyID string `json:"strategy_id,omitempty"`
 }
 
 type TaskListOptions struct {
@@ -613,6 +624,78 @@ func (service *Service) GetBuildStatuses(ctx context.Context, repository Reposit
 	return results, nil
 }
 
+// GetAutoMerge returns the auto-merge configuration for a pull request.
+// When auto-merge is not configured, Enabled is false and no error is returned.
+func (service *Service) GetAutoMerge(ctx context.Context, repository RepositoryRef, pullRequestID string) (AutoMerge, error) {
+	if err := validateRepositoryRef(repository); err != nil {
+		return AutoMerge{}, err
+	}
+
+	resolvedID, err := normalizePullRequestID(pullRequestID)
+	if err != nil {
+		return AutoMerge{}, err
+	}
+
+	var response autoMergeValue
+	err = service.client.GetJSON(ctx, fmt.Sprintf("%s/%s/auto-merge", pullRequestPath(repository), resolvedID), nil, &response)
+	if err != nil {
+		if apperrors.IsKind(err, apperrors.KindNotFound) {
+			return AutoMerge{Enabled: false}, nil
+		}
+		return AutoMerge{}, err
+	}
+
+	strategyID := ""
+	if response.StrategyId != nil {
+		strategyID = *response.StrategyId
+	}
+	return AutoMerge{Enabled: true, StrategyID: strategyID}, nil
+}
+
+// EnableAutoMerge enables auto-merge on a pull request using the given merge strategy.
+// Valid strategy values: no-ff, ff-only, rebase-no-ff, rebase-ff-only, squash, squash-ff-only.
+func (service *Service) EnableAutoMerge(ctx context.Context, repository RepositoryRef, pullRequestID string, strategyID string) (AutoMerge, error) {
+	if err := validateRepositoryRef(repository); err != nil {
+		return AutoMerge{}, err
+	}
+
+	resolvedID, err := normalizePullRequestID(pullRequestID)
+	if err != nil {
+		return AutoMerge{}, err
+	}
+
+	strategy := strings.TrimSpace(strategyID)
+	if strategy == "" {
+		strategy = "no-ff"
+	}
+
+	payload := map[string]any{"strategyId": strategy}
+	var response autoMergeValue
+	if err := service.client.PostJSON(ctx, fmt.Sprintf("%s/%s/auto-merge", pullRequestPath(repository), resolvedID), nil, payload, &response); err != nil {
+		return AutoMerge{}, err
+	}
+
+	responseStrategy := strategy
+	if response.StrategyId != nil {
+		responseStrategy = *response.StrategyId
+	}
+	return AutoMerge{Enabled: true, StrategyID: responseStrategy}, nil
+}
+
+// DisableAutoMerge removes the auto-merge configuration from a pull request.
+func (service *Service) DisableAutoMerge(ctx context.Context, repository RepositoryRef, pullRequestID string) error {
+	if err := validateRepositoryRef(repository); err != nil {
+		return err
+	}
+
+	resolvedID, err := normalizePullRequestID(pullRequestID)
+	if err != nil {
+		return err
+	}
+
+	return service.client.DeleteJSON(ctx, fmt.Sprintf("%s/%s/auto-merge", pullRequestPath(repository), resolvedID), nil, nil, nil)
+}
+
 func normalizeState(state string) (string, error) {
 	resolved := strings.ToLower(strings.TrimSpace(state))
 	if resolved == "" {
@@ -695,6 +778,7 @@ func mapPullRequest(raw pullRequestValue) PullRequest {
 		State:        strings.TrimSpace(raw.State),
 		Open:         raw.Open,
 		Closed:       raw.Closed,
+		Draft:        raw.Draft,
 		Version:      raw.Version,
 		Author:       author,
 		SourceBranch: branchDisplayName(raw.FromRef),
@@ -882,6 +966,10 @@ func buildCreatePayload(input CreateInput) (map[string]any, error) {
 		"toRef":   map[string]any{"id": normalizeBranchRef(toRef)},
 	}
 
+	if input.Draft {
+		payload["draft"] = true
+	}
+
 	if description := strings.TrimSpace(input.Description); description != "" {
 		payload["description"] = description
 	}
@@ -918,9 +1006,12 @@ func buildUpdatePayload(input UpdateInput) (map[string]any, error) {
 	if description := strings.TrimSpace(input.Description); description != "" {
 		payload["description"] = description
 	}
+	if input.Draft != nil {
+		payload["draft"] = *input.Draft
+	}
 
 	if len(payload) == 1 {
-		return nil, apperrors.New(apperrors.KindValidation, "at least one of title or description is required", nil)
+		return nil, apperrors.New(apperrors.KindValidation, "at least one of title, description, or draft is required", nil)
 	}
 
 	return payload, nil
@@ -1048,6 +1139,7 @@ type pullRequestValue struct {
 	State        string                   `json:"state"`
 	Open         bool                     `json:"open"`
 	Closed       bool                     `json:"closed"`
+	Draft        bool                     `json:"draft"`
 	Version      int                      `json:"version"`
 	CreatedDate  int64                    `json:"createdDate"`
 	UpdatedDate  int64                    `json:"updatedDate"`
@@ -1055,6 +1147,10 @@ type pullRequestValue struct {
 	Participants []pullRequestParticipant `json:"participants"`
 	FromRef      *pullRequestRef          `json:"fromRef"`
 	ToRef        *pullRequestRef          `json:"toRef"`
+}
+
+type autoMergeValue struct {
+	StrategyId *string `json:"strategyId"`
 }
 
 type pullRequestParticipant struct {

--- a/internal/services/pullrequest/service.go
+++ b/internal/services/pullrequest/service.go
@@ -66,11 +66,11 @@ type Reviewer struct {
 }
 
 type CreateInput struct {
-	FromRef     string   `json:"from_ref"`
-	ToRef       string   `json:"to_ref"`
-	Title       string   `json:"title"`
-	Description string   `json:"description,omitempty"`
-	Draft       bool     `json:"draft,omitempty"`
+	FromRef     string `json:"from_ref"`
+	ToRef       string `json:"to_ref"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+	Draft       bool   `json:"draft,omitempty"`
 	// Reviewers lists usernames to add as PR reviewers on creation. Blank and
 	// whitespace-only entries are ignored; an empty result omits reviewers from
 	// the request payload.

--- a/internal/services/pullrequest/service_test.go
+++ b/internal/services/pullrequest/service_test.go
@@ -1094,4 +1094,3 @@ func TestEnableAutoMergeDefaultStrategy(t *testing.T) {
 		t.Fatalf("expected request body to contain no-ff, got: %s", receivedBody)
 	}
 }
-

--- a/internal/services/pullrequest/service_test.go
+++ b/internal/services/pullrequest/service_test.go
@@ -824,3 +824,274 @@ func TestBuildCreatePayloadWithBlankReviewers(t *testing.T) {
 	}
 }
 
+func TestBuildCreatePayloadWithDraft(t *testing.T) {
+	payload, err := buildCreatePayload(CreateInput{
+		FromRef: "feature/my-work",
+		ToRef:   "main",
+		Title:   "My PR",
+		Draft:   true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	draft, ok := payload["draft"].(bool)
+	if !ok || !draft {
+		t.Fatalf("expected draft=true in payload, got %v", payload["draft"])
+	}
+}
+
+func TestBuildCreatePayloadNoDraftByDefault(t *testing.T) {
+	payload, err := buildCreatePayload(CreateInput{
+		FromRef: "feature/my-work",
+		ToRef:   "main",
+		Title:   "My PR",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, exists := payload["draft"]; exists {
+		t.Fatalf("expected no draft key when Draft=false, got %v", payload["draft"])
+	}
+}
+
+func TestBuildUpdatePayloadWithDraft(t *testing.T) {
+	trueVal := true
+	payload, err := buildUpdatePayload(UpdateInput{
+		Title:   "Updated title",
+		Version: 1,
+		Draft:   &trueVal,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if payload["draft"] != true {
+		t.Fatalf("expected draft=true in update payload, got %v", payload["draft"])
+	}
+}
+
+func TestBuildUpdatePayloadDraftOnlyRequiresVersion(t *testing.T) {
+	falseVal := false
+	payload, err := buildUpdatePayload(UpdateInput{
+		Version: 2,
+		Draft:   &falseVal,
+	})
+	if err != nil {
+		t.Fatalf("expected draft-only update to succeed, got: %v", err)
+	}
+
+	if payload["draft"] != false {
+		t.Fatalf("expected draft=false in update payload, got %v", payload["draft"])
+	}
+	if payload["version"] != 2 {
+		t.Fatalf("expected version=2 in update payload, got %v", payload["version"])
+	}
+}
+
+func TestBuildUpdatePayloadValidationRequiresField(t *testing.T) {
+	_, err := buildUpdatePayload(UpdateInput{Version: 1})
+	if err == nil || apperrors.ExitCode(err) != 2 {
+		t.Fatalf("expected validation error exit code 2 when no fields set, got: %v", err)
+	}
+}
+
+func TestCreateDraftPullRequest(t *testing.T) {
+	var receivedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests" {
+			receivedBody = readBody(t, r)
+			_, _ = fmt.Fprint(w, `{"id":50,"title":"Draft PR","state":"OPEN","open":true,"closed":false,"draft":true,"fromRef":{"displayId":"feature/draft"},"toRef":{"displayId":"main"}}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	t.Setenv("BITBUCKET_URL", server.URL)
+	t.Setenv("BITBUCKET_PROJECT_KEY", "TEST")
+
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	service := NewService(httpclient.NewFromConfig(cfg))
+	created, err := service.Create(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, CreateInput{
+		FromRef: "feature/draft",
+		ToRef:   "main",
+		Title:   "Draft PR",
+		Draft:   true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !created.Draft {
+		t.Fatal("expected created PR to have Draft=true")
+	}
+	if !strings.Contains(receivedBody, `"draft":true`) {
+		t.Fatalf("expected request body to contain draft:true, got: %s", receivedBody)
+	}
+}
+
+func TestUpdateDraftPullRequest(t *testing.T) {
+	var receivedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && r.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/50" {
+			receivedBody = readBody(t, r)
+			_, _ = fmt.Fprint(w, `{"id":50,"title":"Draft PR","state":"OPEN","open":true,"closed":false,"draft":false,"version":2,"fromRef":{"displayId":"feature/draft"},"toRef":{"displayId":"main"}}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	t.Setenv("BITBUCKET_URL", server.URL)
+	t.Setenv("BITBUCKET_PROJECT_KEY", "TEST")
+
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	falseVal := false
+	service := NewService(httpclient.NewFromConfig(cfg))
+	updated, err := service.Update(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, "50", UpdateInput{
+		Title:   "Draft PR",
+		Version: 1,
+		Draft:   &falseVal,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated.Draft {
+		t.Fatal("expected updated PR to have Draft=false")
+	}
+	if !strings.Contains(receivedBody, `"draft":false`) {
+		t.Fatalf("expected request body to contain draft:false, got: %s", receivedBody)
+	}
+}
+
+func TestAutoMergeEnableDisableGet(t *testing.T) {
+	const autoMergePath = "/rest/api/latest/projects/TEST/repos/demo/pull-requests/42/auto-merge"
+	autoMergeEnabled := true
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != autoMergePath {
+			http.NotFound(w, r)
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			if !autoMergeEnabled {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = fmt.Fprint(w, `{"strategyId":"no-ff"}`)
+		case http.MethodPost:
+			autoMergeEnabled = true
+			_, _ = fmt.Fprint(w, `{"strategyId":"rebase-ff-only"}`)
+		case http.MethodDelete:
+			autoMergeEnabled = false
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("BITBUCKET_URL", server.URL)
+	t.Setenv("BITBUCKET_PROJECT_KEY", "TEST")
+
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	service := NewService(httpclient.NewFromConfig(cfg))
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+
+	// GET when enabled
+	am, err := service.GetAutoMerge(context.Background(), repo, "42")
+	if err != nil {
+		t.Fatalf("GetAutoMerge: unexpected error: %v", err)
+	}
+	if !am.Enabled || am.StrategyID != "no-ff" {
+		t.Fatalf("GetAutoMerge: expected enabled=true strategy=no-ff, got %+v", am)
+	}
+
+	// Enable with a specific strategy
+	enabled, err := service.EnableAutoMerge(context.Background(), repo, "42", "rebase-ff-only")
+	if err != nil {
+		t.Fatalf("EnableAutoMerge: unexpected error: %v", err)
+	}
+	if !enabled.Enabled || enabled.StrategyID != "rebase-ff-only" {
+		t.Fatalf("EnableAutoMerge: expected enabled=true strategy=rebase-ff-only, got %+v", enabled)
+	}
+
+	// Disable
+	if err := service.DisableAutoMerge(context.Background(), repo, "42"); err != nil {
+		t.Fatalf("DisableAutoMerge: unexpected error: %v", err)
+	}
+
+	// GET after disable returns not-found → Enabled=false, no error
+	am, err = service.GetAutoMerge(context.Background(), repo, "42")
+	if err != nil {
+		t.Fatalf("GetAutoMerge after disable: unexpected error: %v", err)
+	}
+	if am.Enabled {
+		t.Fatalf("GetAutoMerge after disable: expected enabled=false, got %+v", am)
+	}
+}
+
+func TestAutoMergeValidation(t *testing.T) {
+	service := NewService(httpclient.NewFromConfig(config.AppConfig{BitbucketURL: "http://localhost:7990"}))
+
+	_, err := service.GetAutoMerge(context.Background(), RepositoryRef{}, "1")
+	if err == nil || apperrors.ExitCode(err) != 2 {
+		t.Fatalf("expected validation error for missing repo ref, got: %v", err)
+	}
+
+	_, err = service.EnableAutoMerge(context.Background(), RepositoryRef{}, "1", "no-ff")
+	if err == nil || apperrors.ExitCode(err) != 2 {
+		t.Fatalf("expected validation error for missing repo ref in enable, got: %v", err)
+	}
+
+	err = service.DisableAutoMerge(context.Background(), RepositoryRef{}, "1")
+	if err == nil || apperrors.ExitCode(err) != 2 {
+		t.Fatalf("expected validation error for missing repo ref in disable, got: %v", err)
+	}
+}
+
+func TestEnableAutoMergeDefaultStrategy(t *testing.T) {
+	var receivedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			receivedBody = readBody(t, r)
+			_, _ = fmt.Fprint(w, `{"strategyId":"no-ff"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	t.Setenv("BITBUCKET_URL", server.URL)
+	t.Setenv("BITBUCKET_PROJECT_KEY", "TEST")
+
+	cfg, _ := config.LoadFromEnv()
+	service := NewService(httpclient.NewFromConfig(cfg))
+
+	// Empty strategy should default to "no-ff"
+	am, err := service.EnableAutoMerge(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, "1", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if am.StrategyID != "no-ff" {
+		t.Fatalf("expected strategy no-ff, got %s", am.StrategyID)
+	}
+	if !strings.Contains(receivedBody, `"strategyId":"no-ff"`) {
+		t.Fatalf("expected request body to contain no-ff, got: %s", receivedBody)
+	}
+}
+

--- a/skills/bb/SKILL.md
+++ b/skills/bb/SKILL.md
@@ -64,7 +64,31 @@ bb repo browse content --repo MYPROJ/payments
 bb branch list --repo MYPROJ/payments --filter feature/my-work
 ```
 
-### 2. Check whether a PR is ready to merge
+### 2. Open a pull request (optionally as a draft)
+
+```bash
+# Open a normal PR
+bb pr create --repo MYPROJ/payments --from-ref feature/my-work --to-ref main --title "Add payment retries"
+
+# Open a draft PR (Bitbucket DC 8.0+) — signals work-in-progress, not ready for review
+bb pr create --repo MYPROJ/payments --from-ref feature/my-work --to-ref main --title "Add payment retries" --draft
+
+# Assign reviewers at creation (repeatable or comma-separated)
+bb pr create --repo MYPROJ/payments --from-ref feature/my-work --to-ref main --title "Add payment retries" --reviewers alice,bob
+```
+
+When a draft PR is ready for review, flip the draft flag (the `--version` is the
+current PR version for optimistic locking, from `bb pr get`):
+
+```bash
+# Mark a draft PR as ready for review
+bb pr update 42 --repo MYPROJ/payments --version 3 --draft=false
+
+# Convert an open PR back to draft
+bb pr update 42 --repo MYPROJ/payments --version 3 --draft
+```
+
+### 3. Check whether a PR is ready to merge
 
 ```bash
 # Get approval status and merge state
@@ -80,7 +104,26 @@ bb build status get <commit-sha>
 bb build required list --repo MYPROJ/payments
 ```
 
-### 3. Address review feedback
+### 4. Merge automatically once checks pass
+
+Auto-merge lets Bitbucket complete the merge as soon as required builds pass and
+all approvals are in, instead of polling and merging manually (Bitbucket DC 8.0+).
+Only enable it after review feedback is addressed and required checks are green.
+
+```bash
+# Inspect current auto-merge configuration
+bb pr auto-merge get --repo MYPROJ/payments 42
+
+# Enable auto-merge (default strategy: no-ff). Prefer a rebase strategy for linear history.
+bb pr auto-merge enable --repo MYPROJ/payments 42 --strategy rebase-ff-only
+
+# Cancel auto-merge
+bb pr auto-merge disable --repo MYPROJ/payments 42
+```
+
+Valid `--strategy` values: `no-ff`, `ff-only`, `rebase-no-ff`, `rebase-ff-only`, `squash`, `squash-ff-only`.
+
+### 5. Address review feedback
 
 ```bash
 # Read inline review comments
@@ -90,7 +133,7 @@ bb pr comment list --repo MYPROJ/payments 42 --path src/main/java/com/example/Pa
 bb repo comment create --repo MYPROJ/payments --pr 42 "Fixed in <commit>. Please re-review."
 ```
 
-### 4. Diagnose a CI failure
+### 6. Diagnose a CI failure
 
 ```bash
 # Get build statuses for a specific commit
@@ -103,7 +146,7 @@ bb commit get --repo MYPROJ/payments <commit-sha>
 bb commit compare --repo MYPROJ/payments --from <green-sha> --to <failing-sha>
 ```
 
-### 5. Release tagging
+### 7. Release tagging
 
 ```bash
 # Find the current latest tag
@@ -159,7 +202,9 @@ bb ai mcp serve --tools get_pull_request,list_pr_comments,get_build_status
 | `get_repository_clone_info` | HTTPS and SSH clone URLs |
 | `resolve_ref` | Check branch/tag exists, get tip SHA |
 | `list_pull_requests` | Open PRs on a repo |
-| `create_pull_request` | Open a PR |
+| `create_pull_request` | Open a PR (supports `draft`) |
+| `enable_auto_merge` | Auto-merge a PR once checks pass |
+| `disable_auto_merge` | Cancel auto-merge on a PR |
 | `add_pr_comment` | Post a review comment |
 | `list_branches` | All branches, with optional filter |
 | `list_tags` | All tags |


### PR DESCRIPTION
Add draft pull request support and auto-merge management to both the
CLI and MCP server interfaces, closing issue #203.

CLI changes:
- bb pr create --draft: create a PR in draft state (Bitbucket DC 8.0+)
- bb pr update --draft / --draft=false: toggle draft state on existing PRs
- bb pr auto-merge get <id>: show auto-merge configuration
- bb pr auto-merge enable <id> [--strategy <s>]: enable auto-merge
- bb pr auto-merge disable <id>: disable auto-merge

Service layer:
- PullRequest.Draft field mapped from API response
- CreateInput.Draft and UpdateInput.Draft added to payloads
- GetAutoMerge / EnableAutoMerge / DisableAutoMerge service methods
  targeting /rest/api/latest/.../pull-requests/{id}/auto-merge

MCP tools:
- create_pull_request gains a draft boolean parameter
- enable_auto_merge tool (unsafe / requires --yolo)
- disable_auto_merge tool (safe by default)

Tests: 13 new unit tests covering draft payload construction,
draft create/update round-trips, auto-merge CRUD, validation,
and default strategy defaulting.

https://claude.ai/code/session_014pnXAZssLnGaaeqx6Qtpgm