### PR TITLE
Add Homebrew tap, AUR, and deb/rpm packaging to the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,6 +472,34 @@ jobs:
             git push origin "$VERSION"
           fi
 
+      - name: Build Linux .deb and .rpm packages
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.46.3
+
+          VERSION_NO_V="${VERSION#v}"
+          workdir="$(mktemp -d)"
+
+          for arch in amd64 arm64; do
+            extract="${workdir}/${arch}"
+            mkdir -p "$extract"
+            tar -xzf "dist/bb_${VERSION_NO_V}_linux_${arch}.tar.gz" -C "$extract"
+
+            for packager in deb rpm; do
+              PKG_ARCH="$arch" \
+              PKG_VERSION="$VERSION_NO_V" \
+              PKG_BINARY="${extract}/bb" \
+                nfpm package \
+                  --config scripts/nfpm.yaml \
+                  --packager "$packager" \
+                  --target "dist/bb_${VERSION_NO_V}_linux_${arch}.${packager}"
+            done
+          done
+
+          ls -1 dist/*.deb dist/*.rpm
+
       - name: Generate checksums
         run: |
           set -euo pipefail
@@ -488,7 +516,7 @@ jobs:
           COSIGN_YES: "true"
         run: |
           set -euo pipefail
-          for file in dist/*.tar.gz dist/*.zip dist/sha256sums.txt; do
+          for file in dist/*.tar.gz dist/*.zip dist/*.deb dist/*.rpm dist/sha256sums.txt; do
             if [[ ! -f "$file" ]]; then
               continue
             fi
@@ -507,6 +535,8 @@ jobs:
           subject-path: |
             dist/*.tar.gz
             dist/*.zip
+            dist/*.deb
+            dist/*.rpm
 
       - name: Publish GitHub release
         env:
@@ -668,3 +698,105 @@ jobs:
           git add bb.json
           git diff --cached --quiet || git commit -m "Update bb to ${VERSION}"
           git push
+
+  homebrew-release:
+    name: Publish to Homebrew tap
+    needs:
+      - determine-version
+      - release
+    if: ${{ needs.determine-version.outputs.should_release == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ needs.determine-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Download checksums from release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "sha256sums.txt" \
+            --output sha256sums.txt
+
+      - name: Update Homebrew formula
+        env:
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone https://github.com/vriesdemichael/homebrew-tap.git tap
+
+          python scripts/gen_homebrew_formula.py \
+            --version "${VERSION#v}" \
+            --repository "$GITHUB_REPOSITORY" \
+            --sha256sums sha256sums.txt \
+            --output tap/Formula/bb.rb
+
+          cd tap
+          git config credential.helper \
+            '!f() { printf "username=x-access-token\npassword=%s\n" "${TAP_GITHUB_TOKEN}"; }; f'
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/bb.rb
+          git diff --cached --quiet || git commit -m "Update bb to ${VERSION}"
+          git push
+
+  aur-release:
+    name: Publish to AUR
+    needs:
+      - determine-version
+      - release
+    if: ${{ needs.determine-version.outputs.should_release == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ needs.determine-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Download checksums from release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "sha256sums.txt" \
+            --output sha256sums.txt
+
+      - name: Generate PKGBUILD
+        run: |
+          set -euo pipefail
+          python scripts/gen_pkgbuild.py \
+            --version "${VERSION#v}" \
+            --repository "$GITHUB_REPOSITORY" \
+            --sha256sums sha256sums.txt \
+            --output PKGBUILD
+          cat PKGBUILD
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
+        with:
+          pkgname: bb-bin
+          pkgbuild: ./PKGBUILD
+          commit_username: github-actions[bot]
+          commit_email: 41898282+github-actions[bot]@users.noreply.github.com
+          ssh_private_key: ${{ secrets.AUR_KEY }}
+          commit_message: Update bb-bin to ${{ needs.determine-version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ scoop bucket add vriesdemichael https://github.com/vriesdemichael/scoop
 scoop install vriesdemichael/bb
 ```
 
+Install on macOS or Linux via Homebrew:
+
+```bash
+brew install vriesdemichael/tap/bb
+```
+
+Install on Arch Linux from the AUR:
+
+```bash
+yay -S bb-bin
+```
+
+Install on Debian/Ubuntu or RHEL/Fedora from the release `.deb`/`.rpm`:
+
+```bash
+VERSION=v1.0.0
+# Debian/Ubuntu
+curl -LO "https://github.com/vriesdemichael/bitbucket-server-cli/releases/download/${VERSION}/bb_${VERSION#v}_linux_amd64.deb"
+sudo dpkg -i "bb_${VERSION#v}_linux_amd64.deb"
+# RHEL/Fedora
+curl -LO "https://github.com/vriesdemichael/bitbucket-server-cli/releases/download/${VERSION}/bb_${VERSION#v}_linux_amd64.rpm"
+sudo rpm -i "bb_${VERSION#v}_linux_amd64.rpm"
+```
+
 Install from Releases (Linux amd64 example):
 
 ```bash

--- a/docs/site/installation-and-quickstart.md
+++ b/docs/site/installation-and-quickstart.md
@@ -13,6 +13,32 @@ scoop bucket add vriesdemichael https://github.com/vriesdemichael/scoop
 scoop install vriesdemichael/bb
 ```
 
+## Install on macOS or Linux via Homebrew
+
+```bash
+brew install vriesdemichael/tap/bb
+```
+
+## Install on Arch Linux from the AUR
+
+```bash
+yay -S bb-bin
+```
+
+## Install on Debian/Ubuntu or RHEL/Fedora
+
+Download the `.deb` or `.rpm` for your architecture from GitHub Releases and install it:
+
+```bash
+VERSION=v1.0.0
+# Debian/Ubuntu
+curl -LO "https://github.com/vriesdemichael/bitbucket-server-cli/releases/download/${VERSION}/bb_${VERSION#v}_linux_amd64.deb"
+sudo dpkg -i "bb_${VERSION#v}_linux_amd64.deb"
+# RHEL/Fedora
+curl -LO "https://github.com/vriesdemichael/bitbucket-server-cli/releases/download/${VERSION}/bb_${VERSION#v}_linux_amd64.rpm"
+sudo rpm -i "bb_${VERSION#v}_linux_amd64.rpm"
+```
+
 ## Install from release artifacts
 
 1. Select a release version (example: `v0.1.0`).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,11 @@ Planned scripts:
 
 Not implemented in minimal scaffold.
 
+Release packaging (used by `.github/workflows/release.yml`):
+- `nfpm.yaml`: nFPM template for building the Linux `.deb`/`.rpm` packages; the workflow exports `PKG_ARCH`, `PKG_VERSION`, and `PKG_BINARY` per architecture
+- `gen_homebrew_formula.py`: render the Homebrew formula pushed to `vriesdemichael/homebrew-tap` from `sha256sums.txt`
+- `gen_pkgbuild.py`: render the AUR `bb-bin` PKGBUILD from `sha256sums.txt`
+
 Coverage reporting workflow:
 - `task quality:coverage:report:update` refreshes combined unit + live `docs/quality/coverage-report.json`
 - `task quality:coverage:report:verify` recomputes and checks the committed report is current

--- a/scripts/gen_homebrew_formula.py
+++ b/scripts/gen_homebrew_formula.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a Homebrew formula for the bb CLI from release checksums.")
+    parser.add_argument("--version", required=True, help="Release version without leading v, for example 1.2.3")
+    parser.add_argument("--repository", required=True, help="GitHub repository in owner/name form")
+    parser.add_argument("--sha256sums", required=True, help="Path to the sha256sums.txt downloaded from the release")
+    parser.add_argument("--output", required=True, help="Path to the formula file to write")
+    return parser.parse_args()
+
+
+def load_hashes(sums_path: Path) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for raw_line in sums_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        digest, _, name = line.partition(" ")
+        name = name.strip().lstrip("*")
+        if name.startswith("./"):
+            name = name[2:]
+        if name:
+            hashes[name] = digest
+    return hashes
+
+
+def hash_for(hashes: dict[str, str], version: str, target: str) -> str:
+    filename = f"bb_{version}_{target}.tar.gz"
+    try:
+        return hashes[filename]
+    except KeyError:
+        raise SystemExit(f"Missing checksum for {filename} in the provided sha256sums file.")
+
+
+def render_formula(version: str, repository: str, hashes: dict[str, str]) -> str:
+    base_url = f"https://github.com/{repository}/releases/download/v{version}"
+    repo_url = f"https://github.com/{repository}"
+    darwin_arm = hash_for(hashes, version, "darwin_arm64")
+    darwin_amd = hash_for(hashes, version, "darwin_amd64")
+    linux_arm = hash_for(hashes, version, "linux_arm64")
+    linux_amd = hash_for(hashes, version, "linux_amd64")
+    return f'''class Bb < Formula
+  desc "A CLI for Bitbucket Server / Bitbucket Data Center"
+  homepage "{repo_url}"
+  version "{version}"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "{base_url}/bb_{version}_darwin_arm64.tar.gz"
+      sha256 "{darwin_arm}"
+    end
+    on_intel do
+      url "{base_url}/bb_{version}_darwin_amd64.tar.gz"
+      sha256 "{darwin_amd}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "{base_url}/bb_{version}_linux_arm64.tar.gz"
+      sha256 "{linux_arm}"
+    end
+    on_intel do
+      url "{base_url}/bb_{version}_linux_amd64.tar.gz"
+      sha256 "{linux_amd}"
+    end
+  end
+
+  def install
+    bin.install "bb"
+  end
+
+  test do
+    system "#{{bin}}/bb", "--version"
+  end
+end
+'''
+
+
+def main() -> None:
+    args = parse_args()
+    hashes = load_hashes(Path(args.sha256sums))
+    formula = render_formula(args.version, args.repository, hashes)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(formula, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_pkgbuild.py
+++ b/scripts/gen_pkgbuild.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate an AUR PKGBUILD for the bb-bin package from release checksums.")
+    parser.add_argument("--version", required=True, help="Release version without leading v, for example 1.2.3")
+    parser.add_argument("--repository", required=True, help="GitHub repository in owner/name form")
+    parser.add_argument("--sha256sums", required=True, help="Path to the sha256sums.txt downloaded from the release")
+    parser.add_argument("--output", required=True, help="Path to the PKGBUILD file to write")
+    return parser.parse_args()
+
+
+def load_hashes(sums_path: Path) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for raw_line in sums_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        digest, _, name = line.partition(" ")
+        name = name.strip().lstrip("*")
+        if name.startswith("./"):
+            name = name[2:]
+        if name:
+            hashes[name] = digest
+    return hashes
+
+
+def hash_for(hashes: dict[str, str], version: str, target: str) -> str:
+    filename = f"bb_{version}_{target}.tar.gz"
+    try:
+        return hashes[filename]
+    except KeyError:
+        raise SystemExit(f"Missing checksum for {filename} in the provided sha256sums file.")
+
+
+def render_pkgbuild(version: str, repository: str, hashes: dict[str, str]) -> str:
+    base_url = f"https://github.com/{repository}/releases/download/v{version}"
+    repo_url = f"https://github.com/{repository}"
+    sha_x86 = hash_for(hashes, version, "linux_amd64")
+    sha_arm = hash_for(hashes, version, "linux_arm64")
+    return f'''# Maintainer: Michael de Vries <vriesdemichael@users.noreply.github.com>
+pkgname=bb-bin
+pkgver={version}
+pkgrel=1
+pkgdesc="A CLI for Bitbucket Server / Bitbucket Data Center"
+arch=('x86_64' 'aarch64')
+url="{repo_url}"
+license=('Apache-2.0')
+provides=('bb')
+conflicts=('bb')
+source_x86_64=("bb-$pkgver-x86_64.tar.gz::{base_url}/bb_{version}_linux_amd64.tar.gz")
+source_aarch64=("bb-$pkgver-aarch64.tar.gz::{base_url}/bb_{version}_linux_arm64.tar.gz")
+sha256sums_x86_64=('{sha_x86}')
+sha256sums_aarch64=('{sha_arm}')
+
+package() {{
+  install -Dm755 "$srcdir/bb" "$pkgdir/usr/bin/bb"
+}}
+'''
+
+
+def main() -> None:
+    args = parse_args()
+    hashes = load_hashes(Path(args.sha256sums))
+    pkgbuild = render_pkgbuild(args.version, args.repository, hashes)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(pkgbuild, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nfpm.yaml
+++ b/scripts/nfpm.yaml
@@ -1,0 +1,17 @@
+# Template consumed by `nfpm package` during the Release workflow.
+# nfpm expands ${VAR} at runtime; the workflow exports PKG_ARCH, PKG_VERSION
+# and PKG_BINARY for each Linux architecture before invoking nfpm.
+name: bb
+arch: ${PKG_ARCH}
+platform: linux
+version: ${PKG_VERSION}
+section: utils
+priority: optional
+maintainer: "Michael de Vries <vriesdemichael@users.noreply.github.com>"
+description: A CLI for Bitbucket Server / Bitbucket Data Center
+vendor: vriesdemichael
+homepage: https://github.com/vriesdemichael/bitbucket-server-cli
+license: Apache-2.0
+contents:
+  - src: ${PKG_BINARY}
+    dst: /usr/bin/bb


### PR DESCRIPTION
Extends the hand-rolled release pipeline (issue #173) with three new distribution channels, reusing the existing signed release artifacts.

## What changed
- **.deb / .rpm**: new *Build Linux .deb and .rpm packages* step in the `release` job (nFPM, pure-Go). Runs **before** checksums so the packages are included in `sha256sums.txt`, cosign-signed, and provenance-attested like the archives.
- **Homebrew**: new `homebrew-release` job pushes `Formula/bb.rb` to `vriesdemichael/homebrew-tap` via `TAP_GITHUB_TOKEN`.
- **AUR**: new `aur-release` job publishes the `bb-bin` PKGBUILD via `KSXGitHub/github-actions-deploy-aur` using `AUR_KEY`.
- New helpers: `scripts/nfpm.yaml`, `scripts/gen_homebrew_formula.py`, `scripts/gen_pkgbuild.py` (generators tested locally).
- Install docs updated (README + installation-and-quickstart).

## Preconditions (already completed)
- `homebrew-tap` repo created; `TAP_GITHUB_TOKEN`, `AUR_KEY` secrets set; AUR account + public key in place.

## Release impact
The single commit's subject is **intentionally non-conventional**, and this PR title is too, so the `determine-version` conventional-commit gate yields `should_release=false` — **merging will not cut a new version**. The new publisher jobs only run on a future real release.

> Note: PyPI bindings (issue #174) intentionally skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)