### PR TITLE
Make the Go test suite pass on Windows dev machines

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -231,12 +231,12 @@ tasks:
     desc: Run live integration tests with coverage profile output over hand-written packages
     cmds:
       - mkdir -p .tmp
-      - go test -tags=live -covermode=count -coverpkg=./cmd/...,./internal/...,./tools/... -coverprofile=.tmp/coverage.live.out ./tests/integration/live
+      - go test -tags=live -timeout 20m -covermode=count -coverpkg=./cmd/...,./internal/...,./tools/... -coverprofile=.tmp/coverage.live.out ./tests/integration/live
       - go tool cover -func=.tmp/coverage.live.out | tail -n 1
 
   test:live:
     desc: Run live integration tests against local Bitbucket stack
-    cmd: go test -tags=live ./tests/integration/live
+    cmd: go test -tags=live -timeout 20m ./tests/integration/live
 
   stack:up:
     desc: Start local Bitbucket + Postgres stack

--- a/internal/cli/browse_command_test.go
+++ b/internal/cli/browse_command_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/url"
 	"os/exec"
+	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -30,7 +32,35 @@ func TestBrowseCommandHomeAndNoBrowser(t *testing.T) {
 	}
 }
 
+func TestBrowserCommand(t *testing.T) {
+	cases := []struct {
+		goos     string
+		wantName string
+		wantArgs []string
+	}{
+		{goos: "windows", wantName: "rundll32", wantArgs: []string{"url.dll,FileProtocolHandler", "https://example.com"}},
+		{goos: "darwin", wantName: "open", wantArgs: []string{"https://example.com"}},
+		{goos: "linux", wantName: "xdg-open", wantArgs: []string{"https://example.com"}},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.goos, func(t *testing.T) {
+			name, args := browserCommand(testCase.goos, "https://example.com")
+			if name != testCase.wantName {
+				t.Fatalf("command name: got %q, want %q", name, testCase.wantName)
+			}
+			if !reflect.DeepEqual(args, testCase.wantArgs) {
+				t.Fatalf("command args: got %#v, want %#v", args, testCase.wantArgs)
+			}
+		})
+	}
+}
+
 func TestOpenInBrowser(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stubs the launcher with sh, which is unavailable on Windows; TestBrowserCommand covers the Windows command mapping")
+	}
+
 	originalExec := browseExecCommand
 	t.Cleanup(func() { browseExecCommand = originalExec })
 

--- a/internal/cli/cmd/ai/skill_test.go
+++ b/internal/cli/cmd/ai/skill_test.go
@@ -210,6 +210,7 @@ func TestResolveInstallPathGlobal(t *testing.T) {
 func TestSkillInstallGlobalWritesFile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir() reads USERPROFILE on Windows, HOME elsewhere
 
 	cmd := New(testSkillDeps("4.0.0"))
 	buf := &bytes.Buffer{}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1913,6 +1914,9 @@ func TestInferenceHelperFunctions(t *testing.T) {
 	})
 
 	t.Run("infer context returns nil when working directory cannot be resolved", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("simulates an unresolvable CWD by deleting it; Windows forbids removing a directory that is the process working directory")
+		}
 		gitBackendFactory = func() git.Backend {
 			return inferenceGitBackendStub{repoRoot: "/tmp/repo", remotes: []git.Remote{{Name: "origin", URL: "https://bitbucket.local/scm/PRJ/repo.git"}}}
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -66,14 +66,6 @@ func TestLoadFromEnvErrorsWhenNoHostConfigured(t *testing.T) {
 }
 
 func TestDotenvCandidatesWalkToRepositoryRoot(t *testing.T) {
-	originalWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chdir(originalWD)
-	})
-
 	repoRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module example.com/testrepo\n\ngo 1.24\n"), 0o600); err != nil {
 		t.Fatalf("write go.mod: %v", err)
@@ -83,9 +75,7 @@ func TestDotenvCandidatesWalkToRepositoryRoot(t *testing.T) {
 	if err := os.MkdirAll(nested, 0o755); err != nil {
 		t.Fatalf("mkdir nested: %v", err)
 	}
-	if err := os.Chdir(nested); err != nil {
-		t.Fatalf("chdir nested: %v", err)
-	}
+	t.Chdir(nested)
 
 	candidates := dotenvCandidates()
 	if len(candidates) < 2 {
@@ -108,14 +98,6 @@ func TestDotenvCandidatesWalkToRepositoryRoot(t *testing.T) {
 }
 
 func TestLoadFromEnvFindsRepositoryDotenvFromNestedWorkingDirectory(t *testing.T) {
-	originalWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chdir(originalWD)
-	})
-
 	repoRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module example.com/testrepo\n\ngo 1.24\n"), 0o600); err != nil {
 		t.Fatalf("write go.mod: %v", err)
@@ -128,9 +110,7 @@ func TestLoadFromEnvFindsRepositoryDotenvFromNestedWorkingDirectory(t *testing.T
 	if err := os.MkdirAll(nested, 0o755); err != nil {
 		t.Fatalf("mkdir nested: %v", err)
 	}
-	if err := os.Chdir(nested); err != nil {
-		t.Fatalf("chdir nested: %v", err)
-	}
+	t.Chdir(nested)
 
 	t.Setenv("BB_DISABLE_STORED_CONFIG", "1")
 	unsetEnvKeys(t,

--- a/internal/workflows/update/runner_test.go
+++ b/internal/workflows/update/runner_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -815,7 +816,9 @@ func TestReplaceBinary(t *testing.T) {
 		if err != nil {
 			t.Fatalf("stat target: %v", err)
 		}
-		if info.Mode().Perm() != 0o700 {
+		// Windows does not model Unix permission bits; os.Chmod only toggles the
+		// read-only flag, so Mode().Perm() reports 0o666 regardless of finalMode.
+		if runtime.GOOS != "windows" && info.Mode().Perm() != 0o700 {
 			t.Fatalf("expected existing mode preserved, got %o", info.Mode().Perm())
 		}
 	})
@@ -829,7 +832,8 @@ func TestReplaceBinary(t *testing.T) {
 		if err != nil {
 			t.Fatalf("stat target: %v", err)
 		}
-		if info.Mode().Perm() != 0o755 {
+		// Windows does not model Unix permission bits (see note above).
+		if runtime.GOOS != "windows" && info.Mode().Perm() != 0o755 {
 			t.Fatalf("expected provided mode, got %o", info.Mode().Perm())
 		}
 	})
@@ -876,7 +880,9 @@ func TestStageWindowsBinary(t *testing.T) {
 		if err != nil {
 			t.Fatalf("stat staged path: %v", err)
 		}
-		if info.Mode().Perm() != 0o700 {
+		// Windows does not model Unix permission bits; os.Chmod only toggles the
+		// read-only flag, so Mode().Perm() reports 0o666 regardless of finalMode.
+		if runtime.GOOS != "windows" && info.Mode().Perm() != 0o700 {
 			t.Fatalf("expected existing mode preserved, got %o", info.Mode().Perm())
 		}
 	})
@@ -907,7 +913,8 @@ func TestStageWindowsBinary(t *testing.T) {
 		if err != nil {
 			t.Fatalf("stat staged path: %v", err)
 		}
-		if info.Mode().Perm() != 0o755 {
+		// Windows does not model Unix permission bits (see note above).
+		if runtime.GOOS != "windows" && info.Mode().Perm() != 0o755 {
 			t.Fatalf("expected provided mode, got %o", info.Mode().Perm())
 		}
 	})
@@ -976,6 +983,9 @@ func TestWindowsSwapHelpers(t *testing.T) {
 	})
 
 	t.Run("detached launch starts worker command", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("launcher fixture is a POSIX shell script and cannot be exec'd as powershell.exe on Windows")
+		}
 		tempDir := t.TempDir()
 		argsPath := filepath.Join(tempDir, "args.txt")
 		launcherPath := filepath.Join(tempDir, "powershell.exe")


### PR DESCRIPTION
Several tests assumed a Unix environment and only ran green on the Linux CI runner. This makes the full Go suite (unit + live) pass on a native Windows dev machine.

## Test fixes (real Windows-user value)
- **ai skill install**: also set `USERPROFILE` so `os.UserHomeDir()` resolves to the temp dir on Windows (it reads `USERPROFILE`, not `HOME`) — also stops the test writing into the real `~/.agents/skills/bb/`.
- **config dotenv tests**: restore CWD via `t.Chdir` so `TempDir` cleanup doesn't fail (Windows can't remove the process's current directory).
- **browse**: add a pure `browserCommand` table test covering the Windows `rundll32 url.dll,FileProtocolHandler` mapping (previously untested).

## Honest skips (technique is inherently Unix-only; real path covered elsewhere)
- `TestOpenInBrowser` (stubs the launcher with `sh`) — Windows command path now covered by the new table test.
- `TestWindowsSwapHelpers/detached launch` (execs a `/bin/sh` script) — real Windows swap covered by the `BB_WINDOWS_SMOKE` smoke test.
- inference "unresolvable CWD" test (deletes its own CWD — impossible on Windows).
- Dropped the meaningless Unix file-permission assertions in the update package (Windows `os.Chmod` only toggles read-only).

## Live test timeout
The live suite (125 tests, each spawning `bb`/`git`) takes ~665s on native Windows (vs ~78s on Linux CI — the difference is Docker Desktop proxy latency + per-exec overhead, not CPU), exceeding Go's 600s default. Set `-timeout 20m` on `test:live` and `test:live:coverage`; Linux/CI is unaffected.

Verified on Windows: full `task test:go:safe` green, full live suite 120/120, and the complete `quality:coverage:origin-main` pre-push gate passes.

Non-conventional title/commits on purpose: test- and CI-config-only, no shipped-binary change, so no version should be cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)