### PR TITLE
feat(quality): OpenAPI spec path coverage across both transports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Run Go tests (targeted non-live package scope)
         run: task test:go:safe
 
+      - name: Verify OpenAPI spec coverage artifact is current
+        run: task quality:spec-coverage:verify
+
   docs-site:
     name: Docs Site
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,17 @@
    git push --no-verify --force-with-lease
    ```
 
+### OpenAPI spec coverage artifact
+
+`docs/quality/spec-coverage.json` is a separate committed artifact that does **not** depend on coverage profiles or live tests. If you change the OpenAPI spec, the generated client, or how `internal/services` calls the API, regenerate it and commit the result:
+
+```bash
+task quality:spec-coverage:update
+git add docs/quality/spec-coverage.json
+```
+
+CI verifies it via `task quality:spec-coverage:verify` (CI-safe, no live infra).
+
 ### When running tests also uncovers a broken test
 
 If the rebase brought in API changes from `main` (e.g. a command's flag changed from `--host` to a positional argument), tests added on the branch may need updating. Fix them in the same amend so history stays clean.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -212,6 +212,21 @@ tasks:
     cmds:
       - go run ./tools/quality-report -report-file docs/quality/coverage-report.json -raw-coverprofile-file docs/quality/coverage.combined.raw.out -scoped-coverprofile-file docs/quality/coverage.combined.scoped.out -verify-committed -min-global-combined {{.COVERAGE_MIN_GLOBAL_COMBINED}} -min-patch {{.COVERAGE_MIN_PATCH}} -min-patch-lines {{.COVERAGE_MIN_PATCH_LINES}} -max-uncovered-small-patch {{.COVERAGE_MAX_UNCOVERED_SMALL_PATCH}} -min-contract {{.COVERAGE_MIN_CONTRACT}}
 
+  quality:spec-coverage:
+    desc: Print OpenAPI spec path coverage across both transports (generated client + raw httpclient)
+    cmds:
+      - go run ./tools/quality-report -spec-coverage
+
+  quality:spec-coverage:update:
+    desc: Update committed OpenAPI spec coverage artifact (CI-safe, no live execution)
+    cmds:
+      - go run ./tools/quality-report -spec-coverage -write-report -spec-coverage-file docs/quality/spec-coverage.json
+
+  quality:spec-coverage:verify:
+    desc: Verify committed OpenAPI spec coverage artifact is current (CI-safe, no live execution)
+    cmds:
+      - go run ./tools/quality-report -spec-coverage -verify-report -spec-coverage-file docs/quality/spec-coverage.json
+
   test:unit:
     desc: Run Go unit tests
     cmd: go test ./cmd/... ./internal/... ./tools/...

--- a/docs/quality/README.md
+++ b/docs/quality/README.md
@@ -8,6 +8,7 @@ This directory contains committed quality artifacts used for local pre-push and 
 - `coverage.combined.raw.out`: committed merged Go coverprofile (unit + live, raw scope) retained for deterministic local quality artifacts.
 - `coverage.combined.scoped.out`: committed merged Go coverprofile (unit + live, scoped include/exclude policy) for Codecov ingestion.
 - `generated-operation-contracts.json`: mapping of generated client operations used by hand-written services to test files that provide contract coverage.
+- `spec-coverage.json`: OpenAPI spec path coverage report — which `(method, path)` operations from the Bitbucket spec the CLI actually reaches, plus the list of unimplemented gaps. See below.
 
 ## Workflow
 
@@ -15,7 +16,32 @@ This directory contains committed quality artifacts used for local pre-push and 
 - Local verify (recompute + compare): `task quality:coverage:report:verify`
 - CI verify (artifact threshold + profile parse checks only): `task quality:coverage:report:verify:committed`
 
+## OpenAPI spec coverage (`spec-coverage.json`)
+
+This report answers "how much of the Bitbucket OpenAPI surface does the CLI
+implement, and what is still missing?" — distinct from Go statement coverage.
+
+Coverage is measured at the `(HTTP method, path)` level and combines **both**
+ways the CLI reaches the API:
+
+1. The generated typed client (`internal/openapi/generated`), restricted to the
+   operations actually called from `internal/services`.
+2. The hand-rolled `internal/transport/httpclient` (`GetJSON`/`PostJSON`/...),
+   whose request paths are resolved statically from the services source.
+
+Tracking both transports matters: services such as `pullrequest` are built
+entirely on the raw httpclient, so a generated-client-only metric reports them
+as uncovered even though they are fully implemented.
+
+- Print coverage: `task quality:spec-coverage`
+- Update artifact: `task quality:spec-coverage:update`
+- Verify artifact (CI-safe, no live execution): `task quality:spec-coverage:verify`
+
+The `gaps` array lists unimplemented operations (method, path, tag, summary) and
+is a useful source when scoping new commands.
+
 ## Notes
 
 - Live integration tests are not run in GitHub Actions due Bitbucket license/infrastructure constraints.
 - This report-driven workflow keeps CI reproducible by validating committed local quality outputs.
+- `spec-coverage.json` is regenerated deterministically from the spec, the generated client, and the services source — it does not depend on the coverage profiles, so it is updated and verified independently of the live-test pipeline.

--- a/docs/quality/spec-coverage.json
+++ b/docs/quality/spec-coverage.json
@@ -1,0 +1,2695 @@
+{
+  "version": 1,
+  "spec": "docs/reference/atlassian/bitbucket-9.4-openapi.json",
+  "covered": 112,
+  "total": 546,
+  "coverage_percent": 20.51282051282051,
+  "by_tag": [
+    {
+      "tag": "",
+      "covered": 0,
+      "total": 2
+    },
+    {
+      "tag": "Authentication",
+      "covered": 0,
+      "total": 64
+    },
+    {
+      "tag": "Builds and Deployments",
+      "covered": 12,
+      "total": 21
+    },
+    {
+      "tag": "Capabilities",
+      "covered": 0,
+      "total": 2
+    },
+    {
+      "tag": "Dashboard",
+      "covered": 1,
+      "total": 2
+    },
+    {
+      "tag": "Deprecated",
+      "covered": 5,
+      "total": 10
+    },
+    {
+      "tag": "Jira Integration",
+      "covered": 0,
+      "total": 4
+    },
+    {
+      "tag": "Markup",
+      "covered": 0,
+      "total": 1
+    },
+    {
+      "tag": "Mirroring (Mirror)",
+      "covered": 0,
+      "total": 21
+    },
+    {
+      "tag": "Mirroring (Upstream)",
+      "covered": 0,
+      "total": 21
+    },
+    {
+      "tag": "Permission Management",
+      "covered": 6,
+      "total": 39
+    },
+    {
+      "tag": "Project",
+      "covered": 22,
+      "total": 73
+    },
+    {
+      "tag": "Pull Requests",
+      "covered": 30,
+      "total": 69
+    },
+    {
+      "tag": "Repository",
+      "covered": 36,
+      "total": 96
+    },
+    {
+      "tag": "Security",
+      "covered": 0,
+      "total": 42
+    },
+    {
+      "tag": "System Maintenance",
+      "covered": 0,
+      "total": 79
+    }
+  ],
+  "gaps": [
+    {
+      "method": "GET",
+      "path": "/access-tokens/latest/projects/{projectKey}",
+      "tag": "Authentication",
+      "summary": "Get project HTTP tokens"
+    },
+    {
+      "method": "PUT",
+      "path": "/access-tokens/latest/projects/{projectKey}",
+      "tag": "Authentication",
+      "summary": "Create project HTTP token"
+    },
+    {
+      "method": "GET",
+      "path": "/access-tokens/latest/projects/{projectKey}/repos/{repositorySlug}",
+      "tag": "Authentication",
+      "summary": "Get repository HTTP tokens"
+    },
+    {
+      "method": "PUT",
+      "path": "/access-tokens/latest/projects/{projectKey}/repos/{repositorySlug}",
+      "tag": "Authentication",
+      "summary": "Create repository HTTP token"
+    },
+    {
+      "method": "DELETE",
+      "path": "/access-tokens/latest/projects/{projectKey}/repos/{repositorySlug}/{tokenId}",
+      "tag": "Authentication",
+      "summary": "Delete a HTTP token"
+    },
+    {
+      "method": "GET",
+      "path": "/access-tokens/latest/projects/{projectKey}/repos/{repositorySlug}/{tokenId}",
+      "tag": "Authentication",
+      "summary": "Get HTTP token by ID"
+    },
+    {
+      "method": "POST",
+      "path": "/access-tokens/latest/projects/{projectKey}/repos/{repositorySlug}/{tokenId}",
+      "tag": "Authentication",
+      "summary": "Update HTTP token"
+    },
+    {
+      "method": "DELETE",
+      "path": "/access-tokens/latest/projects/{projectKey}/{tokenId}",
+      "tag": "Authentication",
+      "summary": "Delete a HTTP token"
+    },
+    {
+      "method": "GET",
+      "path": "/access-tokens/latest/projects/{projectKey}/{tokenId}",
+      "tag": "Authentication",
+      "summary": "Get HTTP token by ID"
+    },
+    {
+      "method": "POST",
+      "path": "/access-tokens/latest/projects/{projectKey}/{tokenId}",
+      "tag": "Authentication",
+      "summary": "Update HTTP token"
+    },
+    {
+      "method": "GET",
+      "path": "/access-tokens/latest/users/{userSlug}",
+      "tag": "Authentication",
+      "summary": "Get personal HTTP tokens"
+    },
+    {
+      "method": "PUT",
+      "path": "/access-tokens/latest/users/{userSlug}",
+      "tag": "Authentication",
+      "summary": "Create personal HTTP token"
+    },
+    {
+      "method": "DELETE",
+      "path": "/access-tokens/latest/users/{userSlug}/{tokenId}",
+      "tag": "Authentication",
+      "summary": "Delete a HTTP token"
+    },
+    {
+      "method": "GET",
+      "path": "/access-tokens/latest/users/{userSlug}/{tokenId}",
+      "tag": "Authentication",
+      "summary": "Get HTTP token by ID"
+    },
+    {
+      "method": "POST",
+      "path": "/access-tokens/latest/users/{userSlug}/{tokenId}",
+      "tag": "Authentication",
+      "summary": "Update HTTP token"
+    },
+    {
+      "method": "GET",
+      "path": "/admin",
+      "tag": "System Maintenance",
+      "summary": "Get global SSH key settings"
+    },
+    {
+      "method": "PUT",
+      "path": "/admin",
+      "tag": "System Maintenance",
+      "summary": "Update global SSH key settings"
+    },
+    {
+      "method": "GET",
+      "path": "/admin/supported-key-types",
+      "tag": "System Maintenance",
+      "summary": "Get supported SSH key algorithms and lengths"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/admin/banner",
+      "tag": "System Maintenance",
+      "summary": "Delete announcement banner"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/banner",
+      "tag": "System Maintenance",
+      "summary": "Get announcement banner"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/admin/banner",
+      "tag": "System Maintenance",
+      "summary": "Update/Set announcement banner"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/cluster",
+      "tag": "System Maintenance",
+      "summary": "Get cluster node information"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/admin/default-branch",
+      "tag": "System Maintenance",
+      "summary": "Clear default branch"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/default-branch",
+      "tag": "System Maintenance",
+      "summary": "Get the default branch"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/admin/default-branch",
+      "tag": "System Maintenance",
+      "summary": "Update/Set default branch"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/git/mesh/config/control-plane.pem",
+      "tag": "System Maintenance",
+      "summary": "Get the control plane PEM"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/git/mesh/diagnostics/connectivity",
+      "tag": "System Maintenance",
+      "summary": "Generate Mesh connectivity report"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/git/mesh/nodes",
+      "tag": "System Maintenance",
+      "summary": "Get all registered Mesh nodes"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/git/mesh/nodes",
+      "tag": "System Maintenance",
+      "summary": "Register new Mesh node"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/admin/git/mesh/nodes/{id}",
+      "tag": "System Maintenance",
+      "summary": "Delete Mesh node"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/git/mesh/nodes/{id}",
+      "tag": "System Maintenance",
+      "summary": "Get Mesh node"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/admin/git/mesh/nodes/{id}",
+      "tag": "System Maintenance",
+      "summary": "Update Mesh node"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/git/mesh/support-zips",
+      "tag": "System Maintenance",
+      "summary": "Get support zips for all Mesh nodes"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/git/mesh/support-zips/{id}",
+      "tag": "System Maintenance",
+      "summary": "Get support zip for node"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/admin/groups",
+      "tag": "Permission Management",
+      "summary": "Remove group"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/groups",
+      "tag": "Permission Management",
+      "summary": "Get groups"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/groups",
+      "tag": "Permission Management",
+      "summary": "Create group"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/groups/add-user",
+      "tag": "Deprecated",
+      "summary": "Add user to group"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/groups/add-users",
+      "tag": "Permission Management",
+      "summary": "Add multiple users to group"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/groups/more-members",
+      "tag": "Permission Management",
+      "summary": "Get group members"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/groups/more-non-members",
+      "tag": "Permission Management",
+      "summary": "Get members not in group"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/groups/remove-user",
+      "tag": "Deprecated",
+      "summary": "Remove user from group"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/license",
+      "tag": "System Maintenance",
+      "summary": "Get license details"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/license",
+      "tag": "System Maintenance",
+      "summary": "Update license"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/admin/mail-server",
+      "tag": "System Maintenance",
+      "summary": "Delete mail configuration"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/mail-server",
+      "tag": "System Maintenance",
+      "summary": "Get mail configuration"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/admin/mail-server",
+      "tag": "System Maintenance",
+      "summary": "Update mail configuration"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/admin/mail-server/sender-address",
+      "tag": "System Maintenance",
+      "summary": "Update mail configuration"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/mail-server/sender-address",
+      "tag": "System Maintenance",
+      "summary": "Get server mail address"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/admin/mail-server/sender-address",
+      "tag": "System Maintenance",
+      "summary": "Update server mail address"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/admin/permissions/groups",
+      "tag": "Permission Management",
+      "summary": "Revoke all global permissions for group"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/permissions/groups",
+      "tag": "Permission Management",
+      "summary": "Get groups with a global permission"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/admin/permissions/groups",
+      "tag": "Permission Management",
+      "summary": "Update global permission for group"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/permissions/groups/none",
+      "tag": "Permission Management",
+      "summary": "Get groups with no global permission"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/admin/permissions/users",
+      "tag": "Permission Management",
+      "summary": "Revoke all global permissions for user"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/permissions/users",
+      "tag": "Permission Management",
+      "summary": "Get users with a global permission"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/admin/permissions/users",
+      "tag": "Permission Management",
+      "summary": "Update global permission for user"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/permissions/users/none",
+      "tag": "Permission Management",
+      "summary": "Get users with no global permission"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/pull-requests/{scmId}",
+      "tag": "Pull Requests",
+      "summary": "Get merge strategies"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/pull-requests/{scmId}",
+      "tag": "Pull Requests",
+      "summary": "Update merge strategies"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/rate-limit/history",
+      "tag": "System Maintenance",
+      "summary": "Get rate limit history"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/rate-limit/settings",
+      "tag": "System Maintenance",
+      "summary": "Get rate limit settings"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/admin/rate-limit/settings",
+      "tag": "System Maintenance",
+      "summary": "Set rate limit"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/rate-limit/settings/users",
+      "tag": "System Maintenance",
+      "summary": "Get rate limit settings for user"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/rate-limit/settings/users",
+      "tag": "System Maintenance",
+      "summary": "Set rate limit settings for users"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/admin/rate-limit/settings/users/{userSlug}",
+      "tag": "System Maintenance",
+      "summary": "Delete user specific rate limit settings"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/rate-limit/settings/users/{userSlug}",
+      "tag": "System Maintenance",
+      "summary": "Get user specific rate limit settings"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/admin/rate-limit/settings/users/{userSlug}",
+      "tag": "System Maintenance",
+      "summary": "Set rate limit settings for user"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/user-directories",
+      "tag": "Permission Management",
+      "summary": "Get directories"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/admin/users",
+      "tag": "Permission Management",
+      "summary": "Remove user"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/users",
+      "tag": "Permission Management",
+      "summary": "Get users"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/users",
+      "tag": "Permission Management",
+      "summary": "Create user"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/admin/users",
+      "tag": "Permission Management",
+      "summary": "Update user details"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/users/add-group",
+      "tag": "Deprecated",
+      "summary": "Add user to group"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/users/add-groups",
+      "tag": "Permission Management",
+      "summary": "Add user to groups"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/admin/users/captcha",
+      "tag": "Permission Management",
+      "summary": "Clear CAPTCHA for user"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/admin/users/credentials",
+      "tag": "Permission Management",
+      "summary": "Set password for user"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/users/erasure",
+      "tag": "Permission Management",
+      "summary": "Check user removal"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/users/erasure",
+      "tag": "Permission Management",
+      "summary": "Erase user information"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/users/more-members",
+      "tag": "Permission Management",
+      "summary": "Get groups for user"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/admin/users/more-non-members",
+      "tag": "Permission Management",
+      "summary": "Find other groups for user"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/users/remove-group",
+      "tag": "Permission Management",
+      "summary": "Remove user from group"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/admin/users/rename",
+      "tag": "Permission Management",
+      "summary": "Rename user"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/application-properties",
+      "tag": "System Maintenance",
+      "summary": "Get application properties"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/build/capabilities",
+      "tag": "Capabilities",
+      "summary": "Get build capabilities"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/dashboard/pull-request-suggestions",
+      "tag": "Dashboard",
+      "summary": "Get pull request suggestions"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/deployment/capabilities",
+      "tag": "Capabilities",
+      "summary": "Get deployment capabilities"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/groups",
+      "tag": "Permission Management",
+      "summary": "Get group names"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/hook-scripts",
+      "tag": "System Maintenance",
+      "summary": "Create a new hook script"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/hook-scripts/{scriptId}",
+      "tag": "System Maintenance",
+      "summary": "Delete a hook script."
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/hook-scripts/{scriptId}",
+      "tag": "System Maintenance",
+      "summary": "Get a hook script"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/hook-scripts/{scriptId}",
+      "tag": "System Maintenance",
+      "summary": "Update a hook script"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/hook-scripts/{scriptId}/content",
+      "tag": "System Maintenance",
+      "summary": "Get hook script content"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/hooks/{hookKey}/avatar",
+      "tag": "Project",
+      "summary": "Get project avatar"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/inbox/pull-requests",
+      "tag": "",
+      "summary": "Get pull requests in inbox"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/inbox/pull-requests/count",
+      "tag": "",
+      "summary": "Get total number of pull requests in inbox"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/labels",
+      "tag": "System Maintenance",
+      "summary": "Get all labels"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/labels/{labelName}",
+      "tag": "System Maintenance",
+      "summary": "Get label"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/labels/{labelName}/labeled",
+      "tag": "System Maintenance",
+      "summary": "Get labelables for label"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/logs/logger/{loggerName}",
+      "tag": "System Maintenance",
+      "summary": "Get current log level"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/logs/logger/{loggerName}/{levelName}",
+      "tag": "System Maintenance",
+      "summary": "Set log level"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/logs/rootLogger",
+      "tag": "System Maintenance",
+      "summary": "Get root log level"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/logs/rootLogger/{levelName}",
+      "tag": "System Maintenance",
+      "summary": "Set root log level"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/markup/preview",
+      "tag": "Markup",
+      "summary": "Preview markdown render"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/migration/exports",
+      "tag": "System Maintenance",
+      "summary": "Start export job"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/migration/exports/preview",
+      "tag": "System Maintenance",
+      "summary": "Preview export"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/migration/exports/{jobId}",
+      "tag": "System Maintenance",
+      "summary": "Get export job details"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/migration/exports/{jobId}/cancel",
+      "tag": "System Maintenance",
+      "summary": "Cancel export job"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/migration/exports/{jobId}/messages",
+      "tag": "System Maintenance",
+      "summary": "Get job messages"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/migration/imports",
+      "tag": "System Maintenance",
+      "summary": "Start import job"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/migration/imports/{jobId}",
+      "tag": "System Maintenance",
+      "summary": "Get import job status"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/migration/imports/{jobId}/cancel",
+      "tag": "System Maintenance",
+      "summary": "Cancel import job"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/migration/imports/{jobId}/messages",
+      "tag": "System Maintenance",
+      "summary": "Get import job messages"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/migration/mesh",
+      "tag": "System Maintenance",
+      "summary": "Start Mesh migration job"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/migration/mesh/preview",
+      "tag": "System Maintenance",
+      "summary": "Preview Mesh migration"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/migration/mesh/repos",
+      "tag": "System Maintenance",
+      "summary": "Find repositories by Mesh migration state"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/migration/mesh/summaries",
+      "tag": "System Maintenance",
+      "summary": "Get all Mesh migration job summaries"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/migration/mesh/summary",
+      "tag": "System Maintenance",
+      "summary": "Get summary for Mesh migration job"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/migration/mesh/{jobId}",
+      "tag": "System Maintenance",
+      "summary": "Get Mesh migration job details"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/migration/mesh/{jobId}/cancel",
+      "tag": "System Maintenance",
+      "summary": "Cancel Mesh migration job"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/migration/mesh/{jobId}/messages",
+      "tag": "System Maintenance",
+      "summary": "Get Mesh migration job messages"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/migration/mesh/{jobId}/summary",
+      "tag": "System Maintenance",
+      "summary": "Get Mesh migration job summary"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/profile/recent/repos",
+      "tag": "Repository",
+      "summary": "Get recently accessed repositories"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/avatar.png",
+      "tag": "Project",
+      "summary": "Get avatar for project"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/avatar.png",
+      "tag": "Project",
+      "summary": "Update project avatar"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/hook-scripts",
+      "tag": "Project",
+      "summary": "Get configured hook scripts"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/hook-scripts/{scriptId}",
+      "tag": "Project",
+      "summary": "Remove a hook script"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/hook-scripts/{scriptId}",
+      "tag": "Project",
+      "summary": "Create/update a hook script"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/permissions",
+      "tag": "Project",
+      "summary": "Revoke project permissions"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/permissions/groups/none",
+      "tag": "Project",
+      "summary": "Get groups without project permission"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/permissions/search",
+      "tag": "Project",
+      "summary": "Search project permissions"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/permissions/users/none",
+      "tag": "Project",
+      "summary": "Get users without project permission"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/permissions/{permission}/all",
+      "tag": "Project",
+      "summary": "Check default project permission"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/permissions/{permission}/all",
+      "tag": "Project",
+      "summary": "Grant project permission"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos",
+      "tag": "Project",
+      "summary": "Get repositories for project"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}",
+      "tag": "Project",
+      "summary": "Get repository"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/archive",
+      "tag": "Repository",
+      "summary": "Stream archive of repository"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/attachments/{attachmentId}",
+      "tag": "Repository",
+      "summary": "Delete an attachment"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/attachments/{attachmentId}",
+      "tag": "Repository",
+      "summary": "Get an attachment"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/attachments/{attachmentId}/metadata",
+      "tag": "Repository",
+      "summary": "Delete attachment metadata"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/attachments/{attachmentId}/metadata",
+      "tag": "Repository",
+      "summary": "Get attachment metadata"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/attachments/{attachmentId}/metadata",
+      "tag": "Repository",
+      "summary": "Save attachment metadata"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/branches",
+      "tag": "Repository",
+      "summary": "Create branch"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/branches/default",
+      "tag": "Deprecated",
+      "summary": "Get default branch"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/branches/default",
+      "tag": "Deprecated",
+      "summary": "Update default branch"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/browse",
+      "tag": "Repository",
+      "summary": "Get file content at revision"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/browse/{path}",
+      "tag": "Repository",
+      "summary": "Edit file"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/changes",
+      "tag": "Repository",
+      "summary": "Get changes made in commit"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/builds",
+      "tag": "Builds and Deployments",
+      "summary": "Delete a specific build status"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/builds",
+      "tag": "Builds and Deployments",
+      "summary": "Get a specific build status"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/builds",
+      "tag": "Builds and Deployments",
+      "summary": "Store a build status"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/changes",
+      "tag": "Repository",
+      "summary": "Get changes in commit"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/deployments",
+      "tag": "Builds and Deployments",
+      "summary": "Delete a deployment"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/deployments",
+      "tag": "Builds and Deployments",
+      "summary": "Get a deployment"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/deployments",
+      "tag": "Builds and Deployments",
+      "summary": "Create or update a deployment"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/diff-stats-summary/{path}",
+      "tag": "Repository",
+      "summary": "Get diff stats summary between revisions"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/diff/{path}",
+      "tag": "Repository",
+      "summary": "Get diff between revisions"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/merge-base",
+      "tag": "Repository",
+      "summary": "Get the common ancestor between two commits"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/pull-requests",
+      "tag": "Pull Requests",
+      "summary": "Get repository pull requests containing commit"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/watch",
+      "tag": "Repository",
+      "summary": "Stop watching commit"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/watch",
+      "tag": "Repository",
+      "summary": "Watch commit"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/compare/changes",
+      "tag": "Repository",
+      "summary": "Compare commits"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/compare/diff{path}",
+      "tag": "Repository",
+      "summary": "Get diff between commits"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/contributing",
+      "tag": "Project",
+      "summary": "Get repository contributing guidelines"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/diff",
+      "tag": "Repository",
+      "summary": "Get raw diff for path"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/forks",
+      "tag": "Project",
+      "summary": "Get repository forks"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/hook-scripts",
+      "tag": "Repository",
+      "summary": "Get hook scripts"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/hook-scripts/{scriptId}",
+      "tag": "Repository",
+      "summary": "Remove a hook script"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/hook-scripts/{scriptId}",
+      "tag": "Repository",
+      "summary": "Create/update a hook script"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/labels",
+      "tag": "Repository",
+      "summary": "Get repository labels"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/labels",
+      "tag": "Repository",
+      "summary": "Add repository label"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/labels/{labelName}",
+      "tag": "Repository",
+      "summary": "Remove repository label"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/last-modified",
+      "tag": "Repository",
+      "summary": "Stream files"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/last-modified/{path}",
+      "tag": "Repository",
+      "summary": "Stream files with last modified commit in path"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/license",
+      "tag": "Project",
+      "summary": "Get repository license"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/participants",
+      "tag": "Pull Requests",
+      "summary": "Search pull request participants"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/permissions",
+      "tag": "Permission Management",
+      "summary": "Revoke all repository permissions for users and groups"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/permissions/groups/none",
+      "tag": "Permission Management",
+      "summary": "Get groups without repository permission"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/permissions/search",
+      "tag": "Permission Management",
+      "summary": "Search repository permissions"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/permissions/users/none",
+      "tag": "Permission Management",
+      "summary": "Get users without repository permission"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}",
+      "tag": "Pull Requests",
+      "summary": "Delete pull request"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/blocker-comments",
+      "tag": "Pull Requests",
+      "summary": "Search pull request comments"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/blocker-comments",
+      "tag": "Pull Requests",
+      "summary": "Add new blocker comment"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/blocker-comments/{commentId}",
+      "tag": "Pull Requests",
+      "summary": "Delete pull request comment"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/blocker-comments/{commentId}",
+      "tag": "Pull Requests",
+      "summary": "Get pull request comment"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/blocker-comments/{commentId}",
+      "tag": "Pull Requests",
+      "summary": "Update pull request comment"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/changes",
+      "tag": "Pull Requests",
+      "summary": "Gets pull request changes"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments/{commentId}/apply-suggestion",
+      "tag": "Pull Requests",
+      "summary": "Apply pull request suggestion"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/commit-message-suggestion",
+      "tag": "Pull Requests",
+      "summary": "Get commit message suggestion"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/commits",
+      "tag": "Pull Requests",
+      "summary": "Get pull request commits"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/diff/{path}",
+      "tag": "Pull Requests",
+      "summary": "Stream a diff within a pull request"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/merge-base",
+      "tag": "Pull Requests",
+      "summary": "Get the common ancestor between the latest commits of the source and target branches of the pull request"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/participants",
+      "tag": "Pull Requests",
+      "summary": "Get pull request participants"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/participants/{userSlug}",
+      "tag": "Pull Requests",
+      "summary": "Change pull request status"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/review",
+      "tag": "Pull Requests",
+      "summary": "Discard pull request review"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/review",
+      "tag": "Pull Requests",
+      "summary": "Get pull request comment thread"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/review",
+      "tag": "Pull Requests",
+      "summary": "Complete pull request review"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/watch",
+      "tag": "Pull Requests",
+      "summary": "Stop watching pull request"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/watch",
+      "tag": "Pull Requests",
+      "summary": "Watch pull request"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/readme",
+      "tag": "Project",
+      "summary": "Get repository readme"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/recreate",
+      "tag": "Project",
+      "summary": "Retry repository creation"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/ref-change-activities",
+      "tag": "Repository",
+      "summary": "Get ref change activity"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/ref-change-activities/branches",
+      "tag": "Repository",
+      "summary": "Get branches with ref change activities for repository"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/related",
+      "tag": "Project",
+      "summary": "Get related repository"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/allowlist",
+      "tag": "Security",
+      "summary": "Find repository secret scanning allowlist rules"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/allowlist",
+      "tag": "Security",
+      "summary": "Create repository secret scanning allowlist rule"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/allowlist/{id}",
+      "tag": "Security",
+      "summary": "Delete a repository secret scanning allowlist rule"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/allowlist/{id}",
+      "tag": "Security",
+      "summary": "Get a repository secret scanning allowlist rule"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/allowlist/{id}",
+      "tag": "Security",
+      "summary": "Edit an existing repository secret scanning allowlist rule"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/exempt",
+      "tag": "Security",
+      "summary": "Delete an exempt repository"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/exempt",
+      "tag": "Security",
+      "summary": "Get whether a repository is exempt"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/exempt",
+      "tag": "Security",
+      "summary": "Exempt a repo from secret scanning"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/rules",
+      "tag": "Security",
+      "summary": "Find repository secret scanning rules"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/rules",
+      "tag": "Security",
+      "summary": "Create repository secret scanning rule"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/rules/{id}",
+      "tag": "Security",
+      "summary": "Delete a repository secret scanning rule"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/rules/{id}",
+      "tag": "Security",
+      "summary": "Get a repository secret scanning rule"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/secret-scanning/rules/{id}",
+      "tag": "Security",
+      "summary": "Edit an existing repository secret scanning rule"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/auto-decline",
+      "tag": "Repository",
+      "summary": "Delete auto decline settings"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/auto-decline",
+      "tag": "Repository",
+      "summary": "Get auto decline settings"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/auto-decline",
+      "tag": "Repository",
+      "summary": "Create auto decline settings"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/auto-merge",
+      "tag": "Repository",
+      "summary": "Delete pull request auto-merge settings"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/auto-merge",
+      "tag": "Repository",
+      "summary": "Get pull request auto-merge settings"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/auto-merge",
+      "tag": "Repository",
+      "summary": "Create or update the pull request auto-merge settings"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/hooks/{hookKey}",
+      "tag": "Repository",
+      "summary": "Delete repository hook"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/hooks/{hookKey}",
+      "tag": "Repository",
+      "summary": "Get repository hook"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/reviewer-groups",
+      "tag": "Pull Requests",
+      "summary": "Get all reviewer groups"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/reviewer-groups",
+      "tag": "Pull Requests",
+      "summary": "Create reviewer group"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/reviewer-groups/{id}",
+      "tag": "Pull Requests",
+      "summary": "Delete reviewer group"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/reviewer-groups/{id}",
+      "tag": "Pull Requests",
+      "summary": "Get reviewer group"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/reviewer-groups/{id}",
+      "tag": "Pull Requests",
+      "summary": "Update reviewer group attributes"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/settings/reviewer-groups/{id}/users",
+      "tag": "Pull Requests",
+      "summary": "Get reviewer group users"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/watch",
+      "tag": "Repository",
+      "summary": "Stop watching repository"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/watch",
+      "tag": "Repository",
+      "summary": "Watch repository"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/webhooks/search",
+      "tag": "Repository",
+      "summary": "Search webhooks"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/webhooks/test",
+      "tag": "Repository",
+      "summary": "Test webhook"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/webhooks/{webhookId}",
+      "tag": "Repository",
+      "summary": "Get webhook"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/webhooks/{webhookId}",
+      "tag": "Repository",
+      "summary": "Update webhook"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/webhooks/{webhookId}/latest",
+      "tag": "Repository",
+      "summary": "Get last webhook invocation details"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/webhooks/{webhookId}/statistics",
+      "tag": "Repository",
+      "summary": "Get webhook statistics"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/webhooks/{webhookId}/statistics/summary",
+      "tag": "Repository",
+      "summary": "Get webhook statistics summary"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/allowlist",
+      "tag": "Security",
+      "summary": "Find project secret scanning allowlist rules"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/allowlist",
+      "tag": "Security",
+      "summary": "Create project secret scanning allowlist rule"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/allowlist/{id}",
+      "tag": "Security",
+      "summary": "Delete a project secret scanning allowlist rule"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/allowlist/{id}",
+      "tag": "Security",
+      "summary": "Get a project secret scanning allowlist rule"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/allowlist/{id}",
+      "tag": "Security",
+      "summary": "Edit an existing project secret scanning allowlist rule"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/exempt",
+      "tag": "Security",
+      "summary": "Find repos exempt from secret scanning for a project"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/exempt",
+      "tag": "Security",
+      "summary": "Bulk exempt repos from secret scanning"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/rules",
+      "tag": "Security",
+      "summary": "Find project secret scanning rules"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/rules",
+      "tag": "Security",
+      "summary": "Create project secret scanning rule"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/rules/{id}",
+      "tag": "Security",
+      "summary": "Delete a project secret scanning rule"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/rules/{id}",
+      "tag": "Security",
+      "summary": "Get a project secret scanning rule"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/secret-scanning/rules/{id}",
+      "tag": "Security",
+      "summary": "Edit an existing project secret scanning rule"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/settings-restriction",
+      "tag": "Project",
+      "summary": "Stop enforcing project restriction"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/settings-restriction",
+      "tag": "Project",
+      "summary": "Get enforcing project setting"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/settings-restriction",
+      "tag": "Project",
+      "summary": "Enforce project restriction"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/settings-restriction/all",
+      "tag": "Project",
+      "summary": "Get all enforcing project settings"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/settings/auto-decline",
+      "tag": "Project",
+      "summary": "Delete auto decline settings"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/settings/auto-decline",
+      "tag": "Project",
+      "summary": "Get auto decline settings"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/settings/auto-decline",
+      "tag": "Project",
+      "summary": "Create/Update auto decline settings"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/settings/auto-merge",
+      "tag": "Project",
+      "summary": "Delete pull request auto-merge settings"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/settings/auto-merge",
+      "tag": "Project",
+      "summary": "Get pull request auto-merge settings"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/settings/auto-merge",
+      "tag": "Project",
+      "summary": "Create or update the pull request auto-merge settings"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/settings/hooks/{hookKey}",
+      "tag": "Project",
+      "summary": "Get a repository hook"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/settings/pull-requests/{scmId}",
+      "tag": "Project",
+      "summary": "Get merge strategy"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/settings/pull-requests/{scmId}",
+      "tag": "Project",
+      "summary": "Update merge strategy"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/settings/reviewer-groups",
+      "tag": "Pull Requests",
+      "summary": "Get all reviewer groups"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/settings/reviewer-groups",
+      "tag": "Pull Requests",
+      "summary": "Create reviewer group"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/settings/reviewer-groups/{id}",
+      "tag": "Pull Requests",
+      "summary": "Delete reviewer group"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/settings/reviewer-groups/{id}",
+      "tag": "Pull Requests",
+      "summary": "Get reviewer group"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/settings/reviewer-groups/{id}",
+      "tag": "Pull Requests",
+      "summary": "Update reviewer group attributes"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/webhooks",
+      "tag": "Project",
+      "summary": "Find webhooks"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/webhooks",
+      "tag": "Project",
+      "summary": "Create webhook"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/projects/{projectKey}/webhooks/test",
+      "tag": "Project",
+      "summary": "Test webhook"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/projects/{projectKey}/webhooks/{webhookId}",
+      "tag": "Project",
+      "summary": "Delete webhook"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/webhooks/{webhookId}",
+      "tag": "Project",
+      "summary": "Get webhook"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/projects/{projectKey}/webhooks/{webhookId}",
+      "tag": "Project",
+      "summary": "Update webhook"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/webhooks/{webhookId}/latest",
+      "tag": "Project",
+      "summary": "Get last webhook invocation details"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/webhooks/{webhookId}/statistics",
+      "tag": "Project",
+      "summary": "Get webhook statistics"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/webhooks/{webhookId}/statistics/summary",
+      "tag": "Project",
+      "summary": "Get webhook statistics summary"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/repos",
+      "tag": "Repository",
+      "summary": "Search for repositories"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/secret-scanning/exempt",
+      "tag": "Security",
+      "summary": "Find all repos exempt from secret scan"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/secret-scanning/exempt",
+      "tag": "Security",
+      "summary": "Bulk exempt repos from secret scanning"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/secret-scanning/rules",
+      "tag": "Security",
+      "summary": "Find global secret scanning rules"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/secret-scanning/rules",
+      "tag": "Security",
+      "summary": "Create global secret scanning rule"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/secret-scanning/rules/{id}",
+      "tag": "Security",
+      "summary": "Delete a global secret scanning rule"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/secret-scanning/rules/{id}",
+      "tag": "Security",
+      "summary": "Get a global secret scanning rule"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/secret-scanning/rules/{id}",
+      "tag": "Security",
+      "summary": "Edit a global secret scanning rule."
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/signing/x509-certificates",
+      "tag": "Security",
+      "summary": "Get all X.509 certificates"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/signing/x509-certificates",
+      "tag": "Security",
+      "summary": "Create an X.509 certificate"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/signing/x509-certificates/crl/{id}",
+      "tag": "Security",
+      "summary": "Update X.509 CRL entries"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/signing/x509-certificates/{id}",
+      "tag": "Security",
+      "summary": "Delete an X.509 certificate"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/system-signing/configuration",
+      "tag": "Security",
+      "summary": "Get system signing configuration"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/system-signing/configuration",
+      "tag": "Security",
+      "summary": "Update system signing configuration"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/users",
+      "tag": "System Maintenance",
+      "summary": "Get all users"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/users",
+      "tag": "System Maintenance",
+      "summary": "Update user details"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/latest/users/credentials",
+      "tag": "System Maintenance",
+      "summary": "Set password"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/users/{userSlug}",
+      "tag": "System Maintenance",
+      "summary": "Get user"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/latest/users/{userSlug}/avatar.png",
+      "tag": "System Maintenance",
+      "summary": "Delete user avatar"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/users/{userSlug}/avatar.png",
+      "tag": "System Maintenance",
+      "summary": "Update user avatar"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/users/{userSlug}/settings",
+      "tag": "System Maintenance",
+      "summary": "Get user settings"
+    },
+    {
+      "method": "POST",
+      "path": "/api/latest/users/{userSlug}/settings",
+      "tag": "System Maintenance",
+      "summary": "Update user settings"
+    },
+    {
+      "method": "DELETE",
+      "path": "/audit/latest/notification-settings/retention-config-review",
+      "tag": "System Maintenance",
+      "summary": "Dismiss retention config notification"
+    },
+    {
+      "method": "GET",
+      "path": "/authconfig/latest/idps",
+      "tag": "Authentication",
+      "summary": "Get all configured IdPs"
+    },
+    {
+      "method": "POST",
+      "path": "/authconfig/latest/idps",
+      "tag": "Authentication",
+      "summary": "Create IdP configuration"
+    },
+    {
+      "method": "DELETE",
+      "path": "/authconfig/latest/idps/{id}",
+      "tag": "Authentication",
+      "summary": "Delete IdP configuration"
+    },
+    {
+      "method": "GET",
+      "path": "/authconfig/latest/idps/{id}",
+      "tag": "Authentication",
+      "summary": "Get IdP configuration"
+    },
+    {
+      "method": "PATCH",
+      "path": "/authconfig/latest/idps/{id}",
+      "tag": "Authentication",
+      "summary": "Update IdP configuration"
+    },
+    {
+      "method": "GET",
+      "path": "/authconfig/latest/jit-users",
+      "tag": "Authentication",
+      "summary": "Get all JIT provisioned users"
+    },
+    {
+      "method": "GET",
+      "path": "/authconfig/latest/login-options",
+      "tag": "Authentication",
+      "summary": "Get available login options"
+    },
+    {
+      "method": "GET",
+      "path": "/authconfig/latest/sso",
+      "tag": "Authentication",
+      "summary": "Get SSO configuration"
+    },
+    {
+      "method": "PATCH",
+      "path": "/authconfig/latest/sso",
+      "tag": "Authentication",
+      "summary": "Update SSO configuration"
+    },
+    {
+      "method": "GET",
+      "path": "/basicauth/latest/config",
+      "tag": "Authentication",
+      "summary": "Get basic auth configuration"
+    },
+    {
+      "method": "PUT",
+      "path": "/basicauth/latest/config",
+      "tag": "Authentication",
+      "summary": "Update basic auth configuration"
+    },
+    {
+      "method": "POST",
+      "path": "/branch-permissions/latest/projects/{projectKey}/repos/{repositorySlug}/restrictions",
+      "tag": "Repository",
+      "summary": "Create multiple ref restrictions"
+    },
+    {
+      "method": "GET",
+      "path": "/branch-permissions/latest/projects/{projectKey}/restrictions",
+      "tag": "Project",
+      "summary": "Search for ref restrictions"
+    },
+    {
+      "method": "POST",
+      "path": "/branch-permissions/latest/projects/{projectKey}/restrictions",
+      "tag": "Project",
+      "summary": "Create multiple ref restrictions"
+    },
+    {
+      "method": "DELETE",
+      "path": "/branch-permissions/latest/projects/{projectKey}/restrictions/{id}",
+      "tag": "Project",
+      "summary": "Delete a ref restriction"
+    },
+    {
+      "method": "GET",
+      "path": "/branch-permissions/latest/projects/{projectKey}/restrictions/{id}",
+      "tag": "Project",
+      "summary": "Get a ref restriction"
+    },
+    {
+      "method": "POST",
+      "path": "/build-status/latest/commits/stats",
+      "tag": "Builds and Deployments",
+      "summary": "Get build status statistics for multiple commits"
+    },
+    {
+      "method": "DELETE",
+      "path": "/comment-likes/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/comments/{commentId}/reactions/{emoticon}",
+      "tag": "Repository",
+      "summary": "Remove a reaction from comment"
+    },
+    {
+      "method": "PUT",
+      "path": "/comment-likes/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/comments/{commentId}/reactions/{emoticon}",
+      "tag": "Repository",
+      "summary": "React to a comment"
+    },
+    {
+      "method": "DELETE",
+      "path": "/comment-likes/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments/{commentId}/reactions/{emoticon}",
+      "tag": "Pull Requests",
+      "summary": "Remove a reaction from a PR comment"
+    },
+    {
+      "method": "PUT",
+      "path": "/comment-likes/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments/{commentId}/reactions/{emoticon}",
+      "tag": "Pull Requests",
+      "summary": "React to a PR comment"
+    },
+    {
+      "method": "GET",
+      "path": "/default-reviewers/latest/projects/{projectKey}/repos/{repositorySlug}/reviewers",
+      "tag": "Pull Requests",
+      "summary": "Get required reviewers for PR creation"
+    },
+    {
+      "method": "DELETE",
+      "path": "/default-tasks/latest/projects/{projectKey}/repos/{repositorySlug}/tasks",
+      "tag": "Repository",
+      "summary": "Deletes all default tasks for the repository"
+    },
+    {
+      "method": "GET",
+      "path": "/default-tasks/latest/projects/{projectKey}/repos/{repositorySlug}/tasks",
+      "tag": "Repository",
+      "summary": "Get a page of default tasks"
+    },
+    {
+      "method": "POST",
+      "path": "/default-tasks/latest/projects/{projectKey}/repos/{repositorySlug}/tasks",
+      "tag": "Repository",
+      "summary": "Add a default task"
+    },
+    {
+      "method": "DELETE",
+      "path": "/default-tasks/latest/projects/{projectKey}/repos/{repositorySlug}/tasks/{taskId}",
+      "tag": "Repository",
+      "summary": "Delete a specific default task"
+    },
+    {
+      "method": "PUT",
+      "path": "/default-tasks/latest/projects/{projectKey}/repos/{repositorySlug}/tasks/{taskId}",
+      "tag": "Repository",
+      "summary": "Update a default task"
+    },
+    {
+      "method": "DELETE",
+      "path": "/default-tasks/latest/projects/{projectKey}/tasks",
+      "tag": "Project",
+      "summary": "Deletes all default tasks for the project"
+    },
+    {
+      "method": "GET",
+      "path": "/default-tasks/latest/projects/{projectKey}/tasks",
+      "tag": "Project",
+      "summary": "Get a page of default tasks"
+    },
+    {
+      "method": "POST",
+      "path": "/default-tasks/latest/projects/{projectKey}/tasks",
+      "tag": "Project",
+      "summary": "Add a default task"
+    },
+    {
+      "method": "DELETE",
+      "path": "/default-tasks/latest/projects/{projectKey}/tasks/{taskId}",
+      "tag": "Project",
+      "summary": "Delete a specific default task"
+    },
+    {
+      "method": "PUT",
+      "path": "/default-tasks/latest/projects/{projectKey}/tasks/{taskId}",
+      "tag": "Project",
+      "summary": "Update a default task"
+    },
+    {
+      "method": "GET",
+      "path": "/git/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/rebase",
+      "tag": "Pull Requests",
+      "summary": "Check PR rebase precondition"
+    },
+    {
+      "method": "POST",
+      "path": "/git/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/rebase",
+      "tag": "Pull Requests",
+      "summary": "Rebase pull request"
+    },
+    {
+      "method": "POST",
+      "path": "/git/latest/projects/{projectKey}/repos/{repositorySlug}/tags",
+      "tag": "Repository",
+      "summary": "Create tag"
+    },
+    {
+      "method": "DELETE",
+      "path": "/gpg/latest/keys",
+      "tag": "Security",
+      "summary": "Delete all GPG keys for user"
+    },
+    {
+      "method": "GET",
+      "path": "/gpg/latest/keys",
+      "tag": "Security",
+      "summary": "Get all GPG keys"
+    },
+    {
+      "method": "POST",
+      "path": "/gpg/latest/keys",
+      "tag": "Security",
+      "summary": "Create a GPG key"
+    },
+    {
+      "method": "DELETE",
+      "path": "/gpg/latest/keys/{fingerprintOrId}",
+      "tag": "Security",
+      "summary": "Delete a GPG key"
+    },
+    {
+      "method": "GET",
+      "path": "/insights/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/annotations",
+      "tag": "Builds and Deployments",
+      "summary": "Get Code Insights annotations for a commit"
+    },
+    {
+      "method": "PUT",
+      "path": "/insights/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/reports/{key}/annotations/{externalId}",
+      "tag": "Builds and Deployments",
+      "summary": "Create or replace a Code Insights annotation"
+    },
+    {
+      "method": "POST",
+      "path": "/jira/latest/comments/{commentId}/issues",
+      "tag": "Jira Integration",
+      "summary": "Create Jira Issue"
+    },
+    {
+      "method": "GET",
+      "path": "/jira/latest/issues/{issueKey}/commits",
+      "tag": "Jira Integration",
+      "summary": "Get changesets for issue key"
+    },
+    {
+      "method": "GET",
+      "path": "/jira/latest/projects/{projectKey}/primary-enhanced-entitylink",
+      "tag": "Jira Integration",
+      "summary": "Get entity link"
+    },
+    {
+      "method": "GET",
+      "path": "/jira/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/issues",
+      "tag": "Jira Integration",
+      "summary": "Get issues for a pull request"
+    },
+    {
+      "method": "GET",
+      "path": "/keys/latest/projects/{projectKey}/repos/{repositorySlug}/ssh",
+      "tag": "Authentication",
+      "summary": "Get repository SSH keys"
+    },
+    {
+      "method": "POST",
+      "path": "/keys/latest/projects/{projectKey}/repos/{repositorySlug}/ssh",
+      "tag": "Authentication",
+      "summary": "Add repository SSH key"
+    },
+    {
+      "method": "DELETE",
+      "path": "/keys/latest/projects/{projectKey}/repos/{repositorySlug}/ssh/{keyId}",
+      "tag": "Authentication",
+      "summary": "Revoke repository SSH key"
+    },
+    {
+      "method": "GET",
+      "path": "/keys/latest/projects/{projectKey}/repos/{repositorySlug}/ssh/{keyId}",
+      "tag": "Authentication",
+      "summary": "Get repository SSH key"
+    },
+    {
+      "method": "PUT",
+      "path": "/keys/latest/projects/{projectKey}/repos/{repositorySlug}/ssh/{keyId}/permission/{permission}",
+      "tag": "Authentication",
+      "summary": "Update repository SSH key permission"
+    },
+    {
+      "method": "GET",
+      "path": "/keys/latest/projects/{projectKey}/ssh",
+      "tag": "Authentication",
+      "summary": "Get SSH key"
+    },
+    {
+      "method": "POST",
+      "path": "/keys/latest/projects/{projectKey}/ssh",
+      "tag": "Authentication",
+      "summary": "Add project SSH key"
+    },
+    {
+      "method": "DELETE",
+      "path": "/keys/latest/projects/{projectKey}/ssh/{keyId}",
+      "tag": "Authentication",
+      "summary": "Revoke project SSH key"
+    },
+    {
+      "method": "GET",
+      "path": "/keys/latest/projects/{projectKey}/ssh/{keyId}",
+      "tag": "Authentication",
+      "summary": "Get project SSH key"
+    },
+    {
+      "method": "PUT",
+      "path": "/keys/latest/projects/{projectKey}/ssh/{keyId}/permission/{permission}",
+      "tag": "Authentication",
+      "summary": "Update project SSH key permission"
+    },
+    {
+      "method": "DELETE",
+      "path": "/keys/latest/ssh/{keyId}",
+      "tag": "Authentication",
+      "summary": "Revoke project SSH key"
+    },
+    {
+      "method": "GET",
+      "path": "/keys/latest/ssh/{keyId}/projects",
+      "tag": "Authentication",
+      "summary": "Get project SSH keys"
+    },
+    {
+      "method": "GET",
+      "path": "/keys/latest/ssh/{keyId}/repos",
+      "tag": "Authentication",
+      "summary": "Get repository SSH key"
+    },
+    {
+      "method": "DELETE",
+      "path": "/mirroring/latest/account/settings/preferred-mirror",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Remove preferred mirror"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/account/settings/preferred-mirror",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Get preferred mirror"
+    },
+    {
+      "method": "POST",
+      "path": "/mirroring/latest/account/settings/preferred-mirror",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Set preferred mirror"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/analyticsSettings",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Get analytics settings from upstream"
+    },
+    {
+      "method": "POST",
+      "path": "/mirroring/latest/authenticate",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Authenticate on behalf of a user"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/farmNodes",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get farm nodes"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/mirrorRepos/{externalRepositoryId}",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get clone URLs"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/mirrorServers",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Get all mirrors"
+    },
+    {
+      "method": "DELETE",
+      "path": "/mirroring/latest/mirrorServers/{mirrorId}",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Delete mirror by ID"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/mirrorServers/{mirrorId}",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Get mirror by ID"
+    },
+    {
+      "method": "PUT",
+      "path": "/mirroring/latest/mirrorServers/{mirrorId}",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Upgrade mirror server"
+    },
+    {
+      "method": "POST",
+      "path": "/mirroring/latest/mirrorServers/{mirrorId}/events",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Publish RepositoryMirrorEvent"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/progress",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get synchronization progress state"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/projects/{projectId}",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Get project"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/projects/{projectId}/repos",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Get hashes for repositories in project"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/repos",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Get content hashes for repositories"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/repos/{repoId}",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Get content hash for a repository"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/repos/{repoId}/mirrors",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Get mirrors for repository"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/requests",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Get mirroring requests"
+    },
+    {
+      "method": "POST",
+      "path": "/mirroring/latest/requests",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Create a mirroring request"
+    },
+    {
+      "method": "DELETE",
+      "path": "/mirroring/latest/requests/{mirroringRequestId}",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Delete a mirroring request"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/requests/{mirroringRequestId}",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Get a mirroring request"
+    },
+    {
+      "method": "POST",
+      "path": "/mirroring/latest/requests/{mirroringRequestId}/accept",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Accept a mirroring request"
+    },
+    {
+      "method": "POST",
+      "path": "/mirroring/latest/requests/{mirroringRequestId}/reject",
+      "tag": "Mirroring (Upstream)",
+      "summary": "Reject a mirroring request"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/supportInfo/out-of-sync-repos/content",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get out-of-sync repositories"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/supportInfo/projects/{projectKey}/repos/{repositorySlug}/repo-lock-owner",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get the repository lock owner for the syncing process"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/supportInfo/projects/{projectKey}/repos/{repositorySlug}/repoSyncStatus",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Gets information about the mirrored repository"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/supportInfo/refChangesQueue",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get items in ref changes queue"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/supportInfo/refChangesQueue/count",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get total number of items in ref changes queue"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/supportInfo/repo-lock-owners",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get all the repository lock owners for the syncing process"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/supportInfo/repoSyncStatus",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get sync status of repositories"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/syncSettings",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get upstream settings"
+    },
+    {
+      "method": "PUT",
+      "path": "/mirroring/latest/syncSettings",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Update upstream settings"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/syncSettings/mode",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get mirror mode"
+    },
+    {
+      "method": "PUT",
+      "path": "/mirroring/latest/syncSettings/mode",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Update mirror mode"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/syncSettings/projects",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get mirrored project IDs"
+    },
+    {
+      "method": "POST",
+      "path": "/mirroring/latest/syncSettings/projects",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Add multiple projects to be mirrored"
+    },
+    {
+      "method": "DELETE",
+      "path": "/mirroring/latest/syncSettings/projects/{projectId}",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Stop mirroring project"
+    },
+    {
+      "method": "POST",
+      "path": "/mirroring/latest/syncSettings/projects/{projectId}",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Add project to be mirrored"
+    },
+    {
+      "method": "GET",
+      "path": "/mirroring/latest/upstreamServer",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Get upstream server"
+    },
+    {
+      "method": "POST",
+      "path": "/mirroring/latest/zdu/end",
+      "tag": "Mirroring (Mirror)",
+      "summary": "End ZDU upgrade on mirror farm"
+    },
+    {
+      "method": "POST",
+      "path": "/mirroring/latest/zdu/start",
+      "tag": "Mirroring (Mirror)",
+      "summary": "Start ZDU upgrade on mirror farm"
+    },
+    {
+      "method": "GET",
+      "path": "/policies/latest/admin/repos/archive",
+      "tag": "System Maintenance",
+      "summary": "Get repository archive policy"
+    },
+    {
+      "method": "PUT",
+      "path": "/policies/latest/admin/repos/archive",
+      "tag": "System Maintenance",
+      "summary": "Update repository archive policy"
+    },
+    {
+      "method": "GET",
+      "path": "/policies/latest/admin/repos/delete",
+      "tag": "System Maintenance",
+      "summary": "Get repository delete policy"
+    },
+    {
+      "method": "PUT",
+      "path": "/policies/latest/admin/repos/delete",
+      "tag": "System Maintenance",
+      "summary": "Update the repository delete policy"
+    },
+    {
+      "method": "DELETE",
+      "path": "/ssh/latest/keys",
+      "tag": "Authentication",
+      "summary": "Delete all user SSH key"
+    },
+    {
+      "method": "GET",
+      "path": "/ssh/latest/keys",
+      "tag": "Authentication",
+      "summary": "Get SSH keys for user"
+    },
+    {
+      "method": "POST",
+      "path": "/ssh/latest/keys",
+      "tag": "Authentication",
+      "summary": "Add SSH key for user"
+    },
+    {
+      "method": "DELETE",
+      "path": "/ssh/latest/keys/{keyId}",
+      "tag": "Authentication",
+      "summary": "Remove SSH key"
+    },
+    {
+      "method": "GET",
+      "path": "/ssh/latest/keys/{keyId}",
+      "tag": "Authentication",
+      "summary": "Get SSH key for user by keyId"
+    },
+    {
+      "method": "GET",
+      "path": "/ssh/latest/settings",
+      "tag": "Authentication",
+      "summary": "Get SSH settings"
+    },
+    {
+      "method": "GET",
+      "path": "/sync/latest/projects/{projectKey}/repos/{repositorySlug}",
+      "tag": "Repository",
+      "summary": "Get synchronization status"
+    },
+    {
+      "method": "POST",
+      "path": "/sync/latest/projects/{projectKey}/repos/{repositorySlug}",
+      "tag": "Repository",
+      "summary": "Disable synchronization"
+    },
+    {
+      "method": "POST",
+      "path": "/sync/latest/projects/{projectKey}/repos/{repositorySlug}/synchronize",
+      "tag": "Repository",
+      "summary": "Manual synchronization"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/authenticate",
+      "tag": "Authentication",
+      "summary": "Authenticate with 2SV"
+    },
+    {
+      "method": "GET",
+      "path": "/tsv/latest/authenticate/captcha",
+      "tag": "Authentication",
+      "summary": "Get CAPTCHA challenge"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/authenticate/recovery-code",
+      "tag": "Authentication",
+      "summary": "Authenticate using recovery code"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/authenticate/totp-code",
+      "tag": "Authentication",
+      "summary": "Authenticate using TOTP code"
+    },
+    {
+      "method": "GET",
+      "path": "/tsv/latest/elevate-permissions",
+      "tag": "Authentication",
+      "summary": "Get elevated session status"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/elevate-permissions/password",
+      "tag": "Authentication",
+      "summary": "Create elevated session with password"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/elevate-permissions/recovery-code",
+      "tag": "Authentication",
+      "summary": "Create elevated session with recovery code"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/elevate-permissions/totp",
+      "tag": "Authentication",
+      "summary": "Create elevated session with TOTP"
+    },
+    {
+      "method": "GET",
+      "path": "/tsv/latest/sso-management-status",
+      "tag": "Authentication",
+      "summary": "Get SSO management status"
+    },
+    {
+      "method": "GET",
+      "path": "/tsv/latest/status",
+      "tag": "Authentication",
+      "summary": "Get two-step verification status"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/totp/complete-enforced-enrollment",
+      "tag": "Authentication",
+      "summary": "Complete enforced enrollment in 2SV"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/totp/complete-enrollment-update",
+      "tag": "Authentication",
+      "summary": "Complete authentication app update for 2SV"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/totp/complete-voluntary-enrollment",
+      "tag": "Authentication",
+      "summary": "Complete voluntary enrollment in 2SV"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/totp/recovery-code/rotate",
+      "tag": "Authentication",
+      "summary": "Rotate recovery code"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/totp/start-enforced-enrollment",
+      "tag": "Authentication",
+      "summary": "Start enforced enrollment in 2SV"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/totp/start-enrollment-update",
+      "tag": "Authentication",
+      "summary": "Start authentication app update for 2SV"
+    },
+    {
+      "method": "POST",
+      "path": "/tsv/latest/totp/start-voluntary-enrollment",
+      "tag": "Authentication",
+      "summary": "Start voluntary enrollment in 2SV"
+    },
+    {
+      "method": "DELETE",
+      "path": "/tsv/latest/totp/unenroll",
+      "tag": "Authentication",
+      "summary": "Uneroll current user from two-step verification"
+    },
+    {
+      "method": "DELETE",
+      "path": "/tsv/latest/totp/unenroll/user/{userName}",
+      "tag": "Authentication",
+      "summary": "Unenroll specific user from two-step verification"
+    }
+  ]
+}

--- a/tools/quality-report/main.go
+++ b/tools/quality-report/main.go
@@ -106,7 +106,17 @@ func main() {
 	minPatchLines := flag.Int("min-patch-lines", 30, "Minimum coverable patch lines required before applying percentage-based patch gate")
 	maxUncoveredSmallPatch := flag.Int("max-uncovered-small-patch", 2, "Maximum uncovered patch lines allowed when coverable patch lines are below --min-patch-lines")
 	minContract := flag.Float64("min-contract", 0.0, "Minimum required used generated operation contract coverage percentage")
+	specCoverageMode := flag.Bool("spec-coverage", false, "Compute OpenAPI spec path coverage (both transports) and exit")
+	specCoverageFile := flag.String("spec-coverage-file", "docs/quality/spec-coverage.json", "Path to spec coverage artifact")
+	openapiSpecPath := flag.String("openapi-spec", "docs/reference/atlassian/bitbucket-9.4-openapi.json", "Path to the Bitbucket OpenAPI spec")
+	generatedClientPath := flag.String("generated-client", "internal/openapi/generated/bitbucket_client.gen.go", "Path to the generated OpenAPI client")
+	servicesRoot := flag.String("services-root", "internal/services", "Root directory scanned for API usage")
 	flag.Parse()
+
+	if *specCoverageMode {
+		runSpecCoverage(*openapiSpecPath, *generatedClientPath, *servicesRoot, *specCoverageFile, *writeReport, *verifyReport)
+		return
+	}
 
 	resolvedMinGlobalCombined := *minGlobalCombined
 	if *minScoped >= 0 {

--- a/tools/quality-report/speccoverage.go
+++ b/tools/quality-report/speccoverage.go
@@ -1,0 +1,650 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// runSpecCoverage computes spec path coverage and writes or verifies the
+// committed artifact, then prints a summary.
+func runSpecCoverage(specPath, generatedPath, servicesRoot, outputPath string, writeReport, verifyReport bool) {
+	report, err := computeSpecCoverage(specPath, generatedPath, servicesRoot)
+	if err != nil {
+		fail("failed to compute spec coverage: %v", err)
+	}
+
+	encoded, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		fail("failed to encode spec coverage report: %v", err)
+	}
+	encoded = append(encoded, '\n')
+
+	fmt.Printf("OpenAPI spec coverage: %.2f%% (%d/%d operations)\n", report.CoveragePercent, report.Covered, report.Total)
+	for _, tag := range report.ByTag {
+		label := tag.Tag
+		if label == "" {
+			label = "(untagged)"
+		}
+		fmt.Printf("  %-26s %3d/%-3d (%.0f%%)\n", label, tag.Covered, tag.Total, percent(tag.Covered, tag.Total))
+	}
+
+	if writeReport {
+		if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+			fail("failed to create spec coverage directory: %v", err)
+		}
+		if err := os.WriteFile(outputPath, encoded, 0o644); err != nil {
+			fail("failed to write spec coverage report: %v", err)
+		}
+		fmt.Printf("Wrote spec coverage report: %s\n", outputPath)
+	}
+
+	if verifyReport {
+		existing, err := os.ReadFile(outputPath)
+		if err != nil {
+			fail("failed to read spec coverage report for verification: %v", err)
+		}
+		if !bytes.Equal(bytes.TrimSpace(existing), bytes.TrimSpace(encoded)) {
+			fail("spec coverage report is out of date: run quality:spec-coverage:update and commit %s", outputPath)
+		}
+		fmt.Printf("Verified spec coverage report: %s\n", outputPath)
+	}
+}
+
+// methodPath is the canonical unit of API coverage: an HTTP verb paired with a
+// normalized request path (path/format parameters collapsed to "{}").
+type methodPath struct {
+	Method string
+	Path   string
+}
+
+type specOperation struct {
+	Method   string
+	Path     string // original spec path, kept for human-readable gap reporting
+	NormPath string
+	Tag      string
+	Summary  string
+}
+
+type specTagCoverage struct {
+	Tag     string `json:"tag"`
+	Covered int    `json:"covered"`
+	Total   int    `json:"total"`
+}
+
+type specGap struct {
+	Method  string `json:"method"`
+	Path    string `json:"path"`
+	Tag     string `json:"tag"`
+	Summary string `json:"summary,omitempty"`
+}
+
+type specCoverageReport struct {
+	Version         int               `json:"version"`
+	Spec            string            `json:"spec"`
+	Covered         int               `json:"covered"`
+	Total           int               `json:"total"`
+	CoveragePercent float64           `json:"coverage_percent"`
+	ByTag           []specTagCoverage `json:"by_tag"`
+	Gaps            []specGap         `json:"gaps"`
+}
+
+var (
+	formatVerbRe = regexp.MustCompile(`%[+#0-9.]*[sdvqtxX]`)
+	pathParamRe  = regexp.MustCompile(`\{[^}]*\}`)
+	httpMethods  = map[string]struct{}{
+		"get": {}, "post": {}, "put": {}, "delete": {}, "patch": {},
+	}
+	jsonHelperMethod = map[string]string{
+		"GetJSON":    "GET",
+		"PostJSON":   "POST",
+		"PutJSON":    "PUT",
+		"DeleteJSON": "DELETE",
+		"PatchJSON":  "PATCH",
+	}
+)
+
+// normalizeAPIPath collapses a spec or constructed path into the canonical form
+// used for joining: query strings dropped, a leading "/rest" stripped, format
+// verbs and "{param}" segments replaced with "{}", and the API version folded to
+// "latest" so 1.0 and latest paths compare equal.
+func normalizeAPIPath(p string) string {
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		p = p[:i]
+	}
+	p = strings.TrimPrefix(p, "/rest")
+	p = formatVerbRe.ReplaceAllString(p, "{}")
+	p = pathParamRe.ReplaceAllString(p, "{}")
+	p = strings.ReplaceAll(p, "/1.0/", "/latest/")
+	return p
+}
+
+// loadSpecOperations reads the OpenAPI document and returns every (method, path)
+// operation it declares.
+func loadSpecOperations(specPath string) ([]specOperation, error) {
+	content, err := os.ReadFile(specPath)
+	if err != nil {
+		return nil, err
+	}
+	var doc struct {
+		Paths map[string]map[string]json.RawMessage `json:"paths"`
+	}
+	if err := json.Unmarshal(content, &doc); err != nil {
+		return nil, fmt.Errorf("parse openapi spec: %w", err)
+	}
+
+	operations := make([]specOperation, 0, len(doc.Paths))
+	for path, item := range doc.Paths {
+		for method, raw := range item {
+			if _, ok := httpMethods[strings.ToLower(method)]; !ok {
+				continue
+			}
+			var op struct {
+				Tags    []string `json:"tags"`
+				Summary string   `json:"summary"`
+			}
+			if err := json.Unmarshal(raw, &op); err != nil {
+				return nil, fmt.Errorf("parse operation %s %s: %w", method, path, err)
+			}
+			tag := ""
+			if len(op.Tags) > 0 {
+				tag = op.Tags[0]
+			}
+			operations = append(operations, specOperation{
+				Method:   strings.ToUpper(method),
+				Path:     path,
+				NormPath: normalizeAPIPath(path),
+				Tag:      tag,
+				Summary:  op.Summary,
+			})
+		}
+	}
+	sort.Slice(operations, func(i, j int) bool {
+		if operations[i].Path != operations[j].Path {
+			return operations[i].Path < operations[j].Path
+		}
+		return operations[i].Method < operations[j].Method
+	})
+	return operations, nil
+}
+
+// parseGeneratedOperationPaths maps each generated operation name (e.g.
+// "GetCommit") to the (method, normalized path) its request builder targets, by
+// reading the New<Operation>Request constructors in the generated client.
+func parseGeneratedOperationPaths(generatedPath string) (map[string]methodPath, error) {
+	fileSet := token.NewFileSet()
+	node, err := parser.ParseFile(fileSet, generatedPath, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	result := map[string]methodPath{}
+	for _, decl := range node.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv != nil || fn.Body == nil {
+			continue
+		}
+		name := fn.Name.Name
+		if !strings.HasPrefix(name, "New") {
+			continue
+		}
+		// Operations with a request body delegate from New<Op>Request to
+		// New<Op>RequestWithBody, and only the latter constructs the path.
+		var op string
+		switch {
+		case strings.HasSuffix(name, "RequestWithBody"):
+			op = name[len("New") : len(name)-len("RequestWithBody")]
+		case strings.HasSuffix(name, "Request"):
+			op = name[len("New") : len(name)-len("Request")]
+		default:
+			continue
+		}
+
+		var method, path string
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			switch stmt := n.(type) {
+			case *ast.AssignStmt:
+				// operationPath := fmt.Sprintf("...") | "..."
+				if path == "" && len(stmt.Lhs) == 1 && len(stmt.Rhs) == 1 {
+					if id, ok := stmt.Lhs[0].(*ast.Ident); ok && id.Name == "operationPath" {
+						if lit, ok := stringFromExpr(stmt.Rhs[0]); ok {
+							path = lit
+						}
+					}
+				}
+			case *ast.CallExpr:
+				// http.NewRequest("GET", ...)
+				if method == "" && isSelector(stmt.Fun, "http", "NewRequest") && len(stmt.Args) >= 1 {
+					if lit, ok := stringLiteral(stmt.Args[0]); ok {
+						method = strings.ToUpper(lit)
+					}
+				}
+			}
+			return method == "" || path == ""
+		})
+
+		if method != "" && path != "" {
+			result[op] = methodPath{Method: method, Path: normalizeAPIPath(path)}
+		}
+	}
+	return result, nil
+}
+
+// usedOperationToName strips the generated WithResponse / WithBody suffixes so a
+// discovered call name maps back to its base operation.
+func usedOperationToName(name string) string {
+	for _, suffix := range []string{"WithBodyWithResponse", "WithResponse", "WithBody"} {
+		if strings.HasSuffix(name, suffix) {
+			return strings.TrimSuffix(name, suffix)
+		}
+	}
+	return name
+}
+
+// collectRawHTTPPaths statically resolves the request paths reached through the
+// hand-rolled httpclient (GetJSON/PostJSON/...) across the services tree. It
+// resolves string literals, fmt.Sprintf templates, single-return path helpers,
+// local path variables, and substitutes function parameters whose call sites
+// pass string literals (e.g. the shared PR transition("merge"|"decline") helper).
+func collectRawHTTPPaths(root string) (map[methodPath]struct{}, error) {
+	fileSet := token.NewFileSet()
+	var funcs []*ast.FuncDecl
+
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		node, err := parser.ParseFile(fileSet, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		for _, decl := range node.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
+				funcs = append(funcs, fn)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Pass 1: literal string arguments passed to each named function, by position.
+	paramLiterals := map[string]map[int][]string{}
+	for _, fn := range funcs {
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := callName(call.Fun)
+			if name == "" {
+				return true
+			}
+			for i, arg := range call.Args {
+				if lit, ok := stringLiteral(arg); ok {
+					if paramLiterals[name] == nil {
+						paramLiterals[name] = map[int][]string{}
+					}
+					if !contains(paramLiterals[name][i], lit) {
+						paramLiterals[name][i] = append(paramLiterals[name][i], lit)
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	// Pass 2: single-return path helpers (functions whose body returns a /rest path).
+	helpers := map[string]string{}
+	for _, fn := range funcs {
+		if fn.Recv != nil {
+			continue
+		}
+		tmpl, ok := helperReturnTemplate(fn)
+		if ok {
+			helpers[fn.Name.Name] = tmpl
+		}
+	}
+
+	resolver := &pathResolver{helpers: helpers, paramLiterals: paramLiterals}
+	covered := map[methodPath]struct{}{}
+
+	// Pass 3: resolve each *JSON call within each function.
+	for _, fn := range funcs {
+		params := paramIndex(fn)
+		locals := resolver.collectLocalPathVars(fn)
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			method, ok := jsonHelperMethod[sel.Sel.Name]
+			if !ok || len(call.Args) < 2 {
+				return true
+			}
+			for _, raw := range resolver.resolvePathRaw(call.Args[1], fn.Name.Name, params, locals) {
+				norm := normalizeAPIPath(raw)
+				if strings.HasPrefix(norm, "/") {
+					covered[methodPath{Method: method, Path: norm}] = struct{}{}
+				}
+			}
+			return true
+		})
+	}
+
+	return covered, nil
+}
+
+type pathResolver struct {
+	helpers       map[string]string
+	paramLiterals map[string]map[int][]string
+}
+
+// collectLocalPathVars maps local identifiers assigned a path-like value within a
+// function to their raw template(s).
+func (r *pathResolver) collectLocalPathVars(fn *ast.FuncDecl) map[string][]string {
+	locals := map[string][]string{}
+	params := paramIndex(fn)
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+			return true
+		}
+		id, ok := assign.Lhs[0].(*ast.Ident)
+		if !ok {
+			return true
+		}
+		for _, tmpl := range r.resolvePathRaw(assign.Rhs[0], fn.Name.Name, params, nil) {
+			if strings.Contains(tmpl, "/") && !contains(locals[id.Name], tmpl) {
+				locals[id.Name] = append(locals[id.Name], tmpl)
+			}
+		}
+		return true
+	})
+	return locals
+}
+
+// resolvePathRaw returns the un-normalized path template(s) an expression can
+// evaluate to. Unresolvable dynamic segments are left as "{}".
+func (r *pathResolver) resolvePathRaw(expr ast.Expr, funcName string, params map[string]int, locals map[string][]string) []string {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if lit, ok := unquote(e); ok && strings.Contains(lit, "/") {
+			return []string{lit}
+		}
+	case *ast.Ident:
+		if locals != nil {
+			if tmpls, ok := locals[e.Name]; ok {
+				return tmpls
+			}
+		}
+	case *ast.CallExpr:
+		name := callName(e.Fun)
+		if tmpl, ok := r.helpers[name]; ok {
+			return []string{tmpl}
+		}
+		if isSelector(e.Fun, "fmt", "Sprintf") && len(e.Args) >= 1 {
+			format, ok := stringLiteral(e.Args[0])
+			if !ok {
+				return nil
+			}
+			options := make([][]string, 0, len(e.Args)-1)
+			for _, arg := range e.Args[1:] {
+				options = append(options, r.resolveArgRaw(arg, funcName, params, locals))
+			}
+			results := []string{}
+			for _, combo := range cartesian(options) {
+				results = append(results, substituteVerbs(format, combo))
+			}
+			return results
+		}
+	}
+	return nil
+}
+
+// resolveArgRaw resolves a single fmt.Sprintf argument into its candidate
+// replacement string(s). Non-path dynamic values collapse to "{}".
+func (r *pathResolver) resolveArgRaw(expr ast.Expr, funcName string, params map[string]int, locals map[string][]string) []string {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if lit, ok := unquote(e); ok {
+			return []string{lit}
+		}
+	case *ast.Ident:
+		if idx, ok := params[e.Name]; ok {
+			if lits := r.paramLiterals[funcName][idx]; len(lits) > 0 {
+				return lits
+			}
+		}
+		if locals != nil {
+			if tmpls, ok := locals[e.Name]; ok {
+				return tmpls
+			}
+		}
+	case *ast.CallExpr:
+		if tmpl, ok := r.helpers[callName(e.Fun)]; ok {
+			return []string{tmpl}
+		}
+	}
+	return []string{"{}"}
+}
+
+// helperReturnTemplate detects functions of the form `return "<path>"` or
+// `return fmt.Sprintf("<path>", ...)` whose path targets the REST API.
+func helperReturnTemplate(fn *ast.FuncDecl) (string, bool) {
+	if fn.Body == nil || len(fn.Body.List) == 0 {
+		return "", false
+	}
+	ret, ok := fn.Body.List[len(fn.Body.List)-1].(*ast.ReturnStmt)
+	if !ok || len(ret.Results) != 1 {
+		return "", false
+	}
+	resolver := &pathResolver{}
+	for _, tmpl := range resolver.resolvePathRaw(ret.Results[0], fn.Name.Name, nil, nil) {
+		if strings.Contains(tmpl, "/rest") {
+			return tmpl, true
+		}
+	}
+	return "", false
+}
+
+// computeSpecCoverage joins the spec against operations reachable through the
+// generated client (restricted to the used set) and the raw httpclient.
+func computeSpecCoverage(specPath, generatedPath, servicesRoot string) (specCoverageReport, error) {
+	specOps, err := loadSpecOperations(specPath)
+	if err != nil {
+		return specCoverageReport{}, fmt.Errorf("load spec operations: %w", err)
+	}
+	generatedPaths, err := parseGeneratedOperationPaths(generatedPath)
+	if err != nil {
+		return specCoverageReport{}, fmt.Errorf("parse generated client: %w", err)
+	}
+	usedOps, err := discoverUsedGeneratedOperations(servicesRoot)
+	if err != nil {
+		return specCoverageReport{}, fmt.Errorf("discover used operations: %w", err)
+	}
+
+	covered := map[methodPath]struct{}{}
+	for _, op := range usedOps {
+		if mp, ok := generatedPaths[usedOperationToName(op)]; ok {
+			covered[mp] = struct{}{}
+		}
+	}
+	rawPaths, err := collectRawHTTPPaths(servicesRoot)
+	if err != nil {
+		return specCoverageReport{}, fmt.Errorf("collect raw http paths: %w", err)
+	}
+	for mp := range rawPaths {
+		covered[mp] = struct{}{}
+	}
+
+	tagOrder := []string{}
+	tagStats := map[string]*specTagCoverage{}
+	gaps := []specGap{}
+	coveredCount := 0
+	for _, op := range specOps {
+		stat, ok := tagStats[op.Tag]
+		if !ok {
+			stat = &specTagCoverage{Tag: op.Tag}
+			tagStats[op.Tag] = stat
+			tagOrder = append(tagOrder, op.Tag)
+		}
+		stat.Total++
+		if _, isCovered := covered[methodPath{Method: op.Method, Path: op.NormPath}]; isCovered {
+			stat.Covered++
+			coveredCount++
+			continue
+		}
+		gaps = append(gaps, specGap{Method: op.Method, Path: op.Path, Tag: op.Tag, Summary: op.Summary})
+	}
+
+	sort.Strings(tagOrder)
+	byTag := make([]specTagCoverage, 0, len(tagOrder))
+	for _, tag := range tagOrder {
+		byTag = append(byTag, *tagStats[tag])
+	}
+
+	return specCoverageReport{
+		Version:         1,
+		Spec:            filepath.ToSlash(specPath),
+		Covered:         coveredCount,
+		Total:           len(specOps),
+		CoveragePercent: percent(coveredCount, len(specOps)),
+		ByTag:           byTag,
+		Gaps:            gaps,
+	}, nil
+}
+
+// --- small AST helpers ---
+
+func isSelector(expr ast.Expr, pkg, sel string) bool {
+	s, ok := expr.(*ast.SelectorExpr)
+	if !ok || s.Sel.Name != sel {
+		return false
+	}
+	id, ok := s.X.(*ast.Ident)
+	return ok && id.Name == pkg
+}
+
+func callName(fun ast.Expr) string {
+	switch f := fun.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		return f.Sel.Name
+	}
+	return ""
+}
+
+func stringLiteral(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	return unquote(lit)
+}
+
+func unquote(lit *ast.BasicLit) (string, bool) {
+	if lit.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+// stringFromExpr resolves a string literal or fmt.Sprintf format literal.
+func stringFromExpr(expr ast.Expr) (string, bool) {
+	if lit, ok := stringLiteral(expr); ok {
+		return lit, true
+	}
+	if call, ok := expr.(*ast.CallExpr); ok && isSelector(call.Fun, "fmt", "Sprintf") && len(call.Args) >= 1 {
+		return stringLiteral(call.Args[0])
+	}
+	return "", false
+}
+
+func paramIndex(fn *ast.FuncDecl) map[string]int {
+	index := map[string]int{}
+	if fn.Type == nil || fn.Type.Params == nil {
+		return index
+	}
+	pos := 0
+	for _, field := range fn.Type.Params.List {
+		if len(field.Names) == 0 {
+			pos++
+			continue
+		}
+		for _, name := range field.Names {
+			index[name.Name] = pos
+			pos++
+		}
+	}
+	return index
+}
+
+// substituteVerbs replaces the i-th format verb in format with reps[i]. Surplus
+// verbs (no replacement supplied) are left intact for later normalization.
+func substituteVerbs(format string, reps []string) string {
+	locs := formatVerbRe.FindAllStringIndex(format, -1)
+	var b strings.Builder
+	last := 0
+	for i, loc := range locs {
+		b.WriteString(format[last:loc[0]])
+		if i < len(reps) {
+			b.WriteString(reps[i])
+		} else {
+			b.WriteString(format[loc[0]:loc[1]])
+		}
+		last = loc[1]
+	}
+	b.WriteString(format[last:])
+	return b.String()
+}
+
+func cartesian(options [][]string) [][]string {
+	result := [][]string{{}}
+	for _, opts := range options {
+		if len(opts) == 0 {
+			opts = []string{"{}"}
+		}
+		next := make([][]string, 0, len(result)*len(opts))
+		for _, prefix := range result {
+			for _, opt := range opts {
+				combo := append(append([]string{}, prefix...), opt)
+				next = append(next, combo)
+			}
+		}
+		result = next
+	}
+	return result
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/quality-report/speccoverage_test.go
+++ b/tools/quality-report/speccoverage_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeAPIPath(t *testing.T) {
+	cases := map[string]string{
+		"/rest/api/latest/projects/%s/repos/%s/pull-requests":      "/api/latest/projects/{}/repos/{}/pull-requests",
+		"/api/latest/projects/{projectKey}/repos/{repositorySlug}": "/api/latest/projects/{}/repos/{}",
+		"/rest/api/1.0/dashboard/pull-requests":                    "/api/latest/dashboard/pull-requests",
+		"/api/latest/projects/%s/repos/%s/commits?since=x":         "/api/latest/projects/{}/repos/{}/commits",
+	}
+	for input, want := range cases {
+		if got := normalizeAPIPath(input); got != want {
+			t.Errorf("normalizeAPIPath(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestSubstituteVerbs(t *testing.T) {
+	got := substituteVerbs("%s/%s/%s", []string{"/rest/api/latest/projects/{}/repos/{}/pull-requests", "{}", "merge"})
+	want := "/rest/api/latest/projects/{}/repos/{}/pull-requests/{}/merge"
+	if got != want {
+		t.Fatalf("substituteVerbs = %q, want %q", got, want)
+	}
+	// Surplus verbs without a replacement are preserved for later normalization.
+	if got := substituteVerbs("%s/%s/extra", []string{"a"}); got != "a/%s/extra" {
+		t.Fatalf("substituteVerbs surplus = %q", got)
+	}
+}
+
+func TestCartesian(t *testing.T) {
+	combos := cartesian([][]string{{"a"}, {"x", "y"}})
+	if len(combos) != 2 {
+		t.Fatalf("expected 2 combos, got %d", len(combos))
+	}
+}
+
+// TestCollectRawHTTPPaths exercises helper resolution, fmt.Sprintf assembly,
+// local path variables, and parameter-literal substitution end to end.
+func TestCollectRawHTTPPaths(t *testing.T) {
+	dir := t.TempDir()
+	src := `package svc
+
+import (
+	"context"
+	"fmt"
+)
+
+type Repo struct{ ProjectKey, Slug string }
+
+func prPath(r Repo) string {
+	return fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/pull-requests", r.ProjectKey, r.Slug)
+}
+
+type Service struct{ client *Client }
+
+func (s *Service) list(ctx context.Context, r Repo) {
+	s.client.GetJSON(ctx, prPath(r), nil, nil)
+}
+
+func (s *Service) create(ctx context.Context, r Repo) {
+	s.client.PostJSON(ctx, prPath(r), nil, nil, nil)
+}
+
+func (s *Service) transition(ctx context.Context, r Repo, id string, action string) {
+	s.client.PostJSON(ctx, fmt.Sprintf("%s/%s/%s", prPath(r), id, action), nil, nil, nil)
+}
+
+func (s *Service) merge(ctx context.Context, r Repo, id string) { s.transition(ctx, r, id, "merge") }
+func (s *Service) decline(ctx context.Context, r Repo, id string) { s.transition(ctx, r, id, "decline") }
+
+func (s *Service) assign(ctx context.Context, r Repo, id string) {
+	path := fmt.Sprintf("%s/%s/participants", prPath(r), id)
+	s.client.PostJSON(ctx, path, nil, nil, nil)
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "service.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	covered, err := collectRawHTTPPaths(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	base := "/api/latest/projects/{}/repos/{}/pull-requests"
+	want := []methodPath{
+		{Method: "GET", Path: base},
+		{Method: "POST", Path: base},
+		{Method: "POST", Path: base + "/{}/merge"},
+		{Method: "POST", Path: base + "/{}/decline"},
+		{Method: "POST", Path: base + "/{}/participants"},
+	}
+	for _, mp := range want {
+		if _, ok := covered[mp]; !ok {
+			t.Errorf("expected covered %+v, missing", mp)
+		}
+	}
+}
+
+func TestParseGeneratedOperationPaths(t *testing.T) {
+	dir := t.TempDir()
+	src := `package openapigenerated
+
+import "net/http"
+
+func NewGetCommitRequest(server string) (*http.Request, error) {
+	operationPath := fmt.Sprintf("/api/latest/projects/%s/repos/%s/commits/%s", a, b, c)
+	_ = operationPath
+	return http.NewRequest("GET", operationPath, nil)
+}
+
+// Body operations delegate to the WithBody constructor, which builds the path.
+func NewCreateCommentRequest(server string, body any) (*http.Request, error) {
+	return NewCreateCommentRequestWithBody(server, "application/json", nil)
+}
+
+func NewCreateCommentRequestWithBody(server string, contentType string, body any) (*http.Request, error) {
+	operationPath := fmt.Sprintf("/api/latest/projects/%s/repos/%s/commits/%s/comments", a, b, c)
+	_ = operationPath
+	return http.NewRequest("POST", operationPath, nil)
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "client.gen.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := parseGeneratedOperationPaths(filepath.Join(dir, "client.gen.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mp := got["GetCommit"]; mp.Method != "GET" || mp.Path != "/api/latest/projects/{}/repos/{}/commits/{}" {
+		t.Errorf("GetCommit = %+v", mp)
+	}
+	if mp := got["CreateComment"]; mp.Method != "POST" || mp.Path != "/api/latest/projects/{}/repos/{}/commits/{}/comments" {
+		t.Errorf("CreateComment (WithBody) = %+v", mp)
+	}
+}
+
+func TestUsedOperationToName(t *testing.T) {
+	cases := map[string]string{
+		"GetCommitWithResponse":              "GetCommit",
+		"SetSettingsWithBodyWithResponse":    "SetSettings",
+		"UpdatePullRequestSettings1WithBody": "UpdatePullRequestSettings1",
+		"GetPullRequestSettings1":            "GetPullRequestSettings1",
+	}
+	for input, want := range cases {
+		if got := usedOperationToName(input); got != want {
+			t.Errorf("usedOperationToName(%q) = %q, want %q", input, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds an automated OpenAPI **spec path coverage** report so unimplemented API surface is visible and tracked in CI.

The existing `generated_contracts` metric only counts generated-client calls of the form `x.client.OpWithResponse(...)`. It is **blind to services built on the raw `internal/transport/httpclient`** — most notably the entire `pullrequest` service — so it under-reports real API coverage (it implies PR endpoints are ~0% covered when create/merge/decline/reopen/approve/auto-merge/participants are all implemented).

## What this does

A new standalone `-spec-coverage` mode in `tools/quality-report` measures coverage at the **`(HTTP method, path)`** level, joining the Bitbucket 9.4 OpenAPI spec against operations reached through **both** transports:

1. The generated typed client (`internal/openapi/generated`), restricted to the operations actually called from `internal/services`.
2. The hand-rolled httpclient (`GetJSON`/`PostJSON`/...), with request paths resolved statically from the services source — handling string literals, `fmt.Sprintf` assembly, single-return path helpers, local path variables, and parameter-literal substitution (so the shared `transition("merge"|"decline"|"reopen")` helper resolves to its real endpoints).

Resolution is undercount-safe: unresolvable dynamic segments collapse to a non-matching placeholder rather than wildcard-matching, so the number is a floor, never inflated.

## Deliverables

- `docs/quality/spec-coverage.json` — committed, deterministic artifact: **112/546 (20.5%)** with per-tag breakdown and the full list of unimplemented gaps (method, path, tag, summary). Does **not** depend on coverage profiles or live tests.
- Task targets: `quality:spec-coverage`, `quality:spec-coverage:update`, `quality:spec-coverage:verify`.
- CI: artifact verification wired into the CI-safe `unit-tests` job.
- Unit tests for normalization, verb substitution, raw-path resolution (incl. parameter substitution), and generated-client `WithBody` parsing.
- Docs: `docs/quality/README.md` and `AGENTS.md` updated with the regeneration workflow.

## Verification

- `go test ./tools/quality-report/` — passing; `gofmt`/`go vet` clean.
- Artifact round-trips: `task quality:spec-coverage:verify` passes against the committed file.
- Spot-checked classification: raw PR endpoints (create/merge/decline/reopen/approve/auto-merge/assign-participant) count as covered; genuine gaps (delete PR, change participant status, merge-base, search participants) remain listed.

Resolves #208

https://claude.ai/code/session_012Ax4aEmr2XgmGi52Grzhk3

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ax4aEmr2XgmGi52Grzhk3)_