### PR TITLE
fix(release): expand env vars in nfpm contents src

### DIFF
--- a/scripts/nfpm.yaml
+++ b/scripts/nfpm.yaml
@@ -1,6 +1,9 @@
 # Template consumed by `nfpm package` during the Release workflow.
 # nfpm expands ${VAR} at runtime; the workflow exports PKG_ARCH, PKG_VERSION
 # and PKG_BINARY for each Linux architecture before invoking nfpm.
+#
+# Top-level fields (arch, version, ...) are always expanded, but env vars in a
+# `contents` entry are only expanded when that entry sets `expand: true`.
 name: bb
 arch: ${PKG_ARCH}
 platform: linux
@@ -15,3 +18,4 @@ license: Apache-2.0
 contents:
   - src: ${PKG_BINARY}
     dst: /usr/bin/bb
+    expand: true


### PR DESCRIPTION
## Problem

The **Build Linux .deb and .rpm packages** step in the release workflow has failed on every push to `main` since deb/rpm packaging was added (2026-06-03), blocking all releases for ~2 weeks. The whole `release` job aborted with:

```
using deb packager...
glob failed: ${PKG_BINARY}: no matching files
```

## Root cause

`scripts/nfpm.yaml` references `${PKG_BINARY}` (exported per-arch by the workflow) in its `contents` source. In nfpm, env-var expansion is **not** uniform: top-level fields (`arch`, `version`, …) are always expanded, but a `contents` entry's `src`/`dst` are only expanded when that entry sets `expand: true` (see `expandEnvVarsContents` in nfpm v2.46.3, which skips entries where `!f.Expand`). Without the flag, nfpm globbed the literal string `${PKG_BINARY}` and failed.

## Fix

Add `expand: true` to the `contents` entry so nfpm expands the binary source path.

## Verification

Reproduced locally with nfpm v2.46.3 using the exact workflow invocation:
- Before: `glob failed: ${PKG_BINARY}`.
- After: both `deb` and `rpm` packages build with exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
