### PR TITLE
fix(clone): support user namespaces (tilde) in repository selectors and clone URLs

### DIFF
--- a/internal/cli/browse_command.go
+++ b/internal/cli/browse_command.go
@@ -354,6 +354,13 @@ func parseHostQualifiedRepositorySelector(value string) (string, repositorySelec
 		return "", repositorySelector{}, false
 	}
 
+	if unescaped, err := url.PathUnescape(project); err == nil {
+		project = unescaped
+	}
+	if unescaped, err := url.PathUnescape(slug); err == nil {
+		slug = unescaped
+	}
+
 	return host, repositorySelector{ProjectKey: project, Slug: slug}, true
 }
 

--- a/internal/cli/repo_clone.go
+++ b/internal/cli/repo_clone.go
@@ -205,7 +205,14 @@ func parseCloneSelector(value, defaultProjectKey string) (repositorySelector, cl
 		if project == "" {
 			return repositorySelector{}, cloneSelectorSlugOnly, apperrors.New(apperrors.KindValidation, "repository must be in PROJECT/slug format when BITBUCKET_PROJECT_KEY is not set", nil)
 		}
-		return repositorySelector{ProjectKey: project, Slug: trimmed}, cloneSelectorSlugOnly, nil
+		if unescaped, err := url.PathUnescape(project); err == nil {
+			project = unescaped
+		}
+		slug := trimmed
+		if unescaped, err := url.PathUnescape(slug); err == nil {
+			slug = unescaped
+		}
+		return repositorySelector{ProjectKey: project, Slug: slug}, cloneSelectorSlugOnly, nil
 	}
 
 	if len(parts) != 2 {
@@ -216,6 +223,13 @@ func parseCloneSelector(value, defaultProjectKey string) (repositorySelector, cl
 	slug := strings.TrimSpace(parts[1])
 	if projectKey == "" || slug == "" {
 		return repositorySelector{}, cloneSelectorProjectSlug, apperrors.New(apperrors.KindValidation, "repository must be in PROJECT/slug format", nil)
+	}
+
+	if unescaped, err := url.PathUnescape(projectKey); err == nil {
+		projectKey = unescaped
+	}
+	if unescaped, err := url.PathUnescape(slug); err == nil {
+		slug = unescaped
 	}
 
 	return repositorySelector{ProjectKey: projectKey, Slug: slug}, cloneSelectorProjectSlug, nil
@@ -445,6 +459,9 @@ func resolveSSHCloneURL(rawInput string, usedURLInput bool, cloneHost string, re
 	if usedURLInput {
 		trimmed := strings.TrimSpace(rawInput)
 		if strings.HasPrefix(trimmed, "git@") || strings.HasPrefix(trimmed, "ssh://") {
+			if unescaped, err := url.PathUnescape(trimmed); err == nil {
+				trimmed = unescaped
+			}
 			return trimmed, true, nil
 		}
 	}

--- a/internal/cli/repo_clone_test.go
+++ b/internal/cli/repo_clone_test.go
@@ -1371,3 +1371,77 @@ type errorReader struct {
 func (r *errorReader) Read(p []byte) (n int, err error) {
 	return 0, r.err
 }
+
+func TestRepoCloneCommandUserNamespace(t *testing.T) {
+	originalFactory := gitBackendFactory
+	stub := &cloneBackendStub{}
+	gitBackendFactory = func() git.Backend { return stub }
+	t.Cleanup(func() { gitBackendFactory = originalFactory })
+
+	t.Setenv("BB_DISABLE_STORED_CONFIG", "1")
+	t.Setenv("BITBUCKET_URL", "https://bitbucket.example.com")
+	t.Setenv("BITBUCKET_PROJECT_KEY", "")
+	t.Setenv("BITBUCKET_REPO_SLUG", "")
+
+	// 1. Test cloning using tilde username format
+	output, err := executeTestCLI(t, "repo", "clone", "~userid/somerepo")
+	if err != nil {
+		t.Fatalf("repo clone with user namespace failed: %v", err)
+	}
+
+	if len(stub.cloneCalls) != 1 {
+		t.Fatalf("expected one clone call, got %d", len(stub.cloneCalls))
+	}
+
+	call := stub.cloneCalls[0]
+	if call.repositoryURL != "git@bitbucket.example.com:scm/~userid/somerepo.git" {
+		t.Fatalf("unexpected clone URL: %s", call.repositoryURL)
+	}
+	if call.options.Directory != "somerepo" {
+		t.Fatalf("unexpected clone directory: %s", call.options.Directory)
+	}
+
+	if !strings.Contains(output, "Cloned ~userid/somerepo into somerepo") {
+		t.Fatalf("unexpected output: %s", output)
+	}
+
+	// 2. Test cloning using full URL with unescaped tilde
+	stub.cloneCalls = nil
+	_, err = executeTestCLI(t, "repo", "clone", "https://bitbucket.example.com/scm/~userid/somerepo.git")
+	if err != nil {
+		t.Fatalf("repo clone with full URL containing tilde failed: %v", err)
+	}
+	if len(stub.cloneCalls) != 1 {
+		t.Fatalf("expected one clone call, got %d", len(stub.cloneCalls))
+	}
+	if stub.cloneCalls[0].repositoryURL != "git@bitbucket.example.com:scm/~userid/somerepo.git" {
+		t.Fatalf("unexpected clone URL: %s", stub.cloneCalls[0].repositoryURL)
+	}
+
+	// 3. Test cloning using full URL with escaped tilde (%7E)
+	stub.cloneCalls = nil
+	_, err = executeTestCLI(t, "repo", "clone", "https://bitbucket.example.com/scm/%7Euserid/somerepo.git")
+	if err != nil {
+		t.Fatalf("repo clone with full URL containing escaped tilde failed: %v", err)
+	}
+	if len(stub.cloneCalls) != 1 {
+		t.Fatalf("expected one clone call, got %d", len(stub.cloneCalls))
+	}
+	if stub.cloneCalls[0].repositoryURL != "git@bitbucket.example.com:scm/~userid/somerepo.git" {
+		t.Fatalf("unexpected clone URL: %s", stub.cloneCalls[0].repositoryURL)
+	}
+
+	// 4. Test cloning using SSH URL with escaped tilde (%7E)
+	stub.cloneCalls = nil
+	_, err = executeTestCLI(t, "repo", "clone", "git@bitbucket.example.com:scm/%7Euserid/somerepo.git")
+	if err != nil {
+		t.Fatalf("repo clone with SSH URL containing escaped tilde failed: %v", err)
+	}
+	if len(stub.cloneCalls) != 1 {
+		t.Fatalf("expected one clone call, got %d", len(stub.cloneCalls))
+	}
+	if stub.cloneCalls[0].repositoryURL != "git@bitbucket.example.com:scm/~userid/somerepo.git" {
+		t.Fatalf("unexpected clone URL: %s", stub.cloneCalls[0].repositoryURL)
+	}
+}
+

--- a/internal/cli/root_helpers.go
+++ b/internal/cli/root_helpers.go
@@ -139,7 +139,16 @@ func parseRepositorySelector(selector string) (repositorySelector, error) {
 		return repositorySelector{}, apperrors.New(apperrors.KindValidation, "--repo must be in PROJECT/slug format", nil)
 	}
 
-	return repositorySelector{ProjectKey: strings.TrimSpace(parts[0]), Slug: strings.TrimSpace(parts[1])}, nil
+	projectKey := strings.TrimSpace(parts[0])
+	slug := strings.TrimSpace(parts[1])
+	if unescaped, err := url.PathUnescape(projectKey); err == nil {
+		projectKey = unescaped
+	}
+	if unescaped, err := url.PathUnescape(slug); err == nil {
+		slug = unescaped
+	}
+
+	return repositorySelector{ProjectKey: projectKey, Slug: slug}, nil
 }
 
 func inferRepositoryContextFromGit(cfg config.AppConfig) (*inferredRepositoryContext, error) {
@@ -449,6 +458,12 @@ func parseBitbucketPath(path string) (projectKey string, slug string, ok bool) {
 				if project == "" || repo == "" {
 					return "", "", false
 				}
+				if unescaped, err := url.PathUnescape(project); err == nil {
+					project = unescaped
+				}
+				if unescaped, err := url.PathUnescape(repo); err == nil {
+					repo = unescaped
+				}
 				return project, repo, true
 			}
 		}
@@ -459,6 +474,12 @@ func parseBitbucketPath(path string) (projectKey string, slug string, ok bool) {
 		repo := strings.TrimSuffix(strings.TrimSpace(parts[len(parts)-1]), ".git")
 		if project == "" || repo == "" {
 			return "", "", false
+		}
+		if unescaped, err := url.PathUnescape(project); err == nil {
+			project = unescaped
+		}
+		if unescaped, err := url.PathUnescape(repo); err == nil {
+			repo = unescaped
 		}
 		return project, repo, true
 	}

--- a/internal/cli/ssh_key.go
+++ b/internal/cli/ssh_key.go
@@ -362,11 +362,11 @@ func resolveRepoSshKeyScope(projectFlag, repoFlag string) (string, string, bool,
 		return projectFlag, "", true, nil
 	}
 	if repoFlag != "" {
-		parts := strings.Split(repoFlag, "/")
-		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		repo, err := parseRepositorySelector(repoFlag)
+		if err != nil {
 			return "", "", false, apperrors.New(apperrors.KindValidation, "--repo must be in projectKey/repositorySlug format", nil)
 		}
-		return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), false, nil
+		return repo.ProjectKey, repo.Slug, false, nil
 	}
 	return "", "", false, apperrors.New(apperrors.KindValidation, "either --project or --repo is required", nil)
 }


### PR DESCRIPTION
Supports repository cloning of user namespaces, e.g., \~<userid>/<somerepo>\ or percent-encoded versions like \%7E<userid>/<somerepo>\.