### PR TITLE
Feat/mcp enhancements and browse fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ __pycache__/
 !/.tmp/.gitkeep
 # Generated Windows PE resource files (created by go-winres during CI builds)
 cmd/bb/rsrc_windows_*.syso
+# Local build artifacts
+bb.exe

--- a/internal/cli/browse.go
+++ b/internal/cli/browse.go
@@ -9,6 +9,7 @@ import (
 	browseservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/browse"
 	commitservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/commit"
 	"github.com/vriesdemichael/bitbucket-server-cli/internal/cli/style"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
 )
 
 func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
@@ -39,7 +40,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
 
 			path := ""
 			if len(args) > 0 {
@@ -91,7 +92,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
 
 			content, err := service.Raw(cmd.Context(), repo, args[0], rawAt)
 			if err != nil {
@@ -123,7 +124,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
 
 			content, err := service.File(cmd.Context(), repo, args[0], browseservice.FileOptions{
 				At:    fileAt,
@@ -180,7 +181,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
 
 			content, err := service.File(cmd.Context(), repo, args[0], browseservice.FileOptions{
 				At:    blameAt,

--- a/internal/cli/repo_cat_edit.go
+++ b/internal/cli/repo_cat_edit.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
 	browseservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/browse"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
 )
 
 func newRepoCatCommand(options *rootOptions) *cobra.Command {
@@ -28,9 +30,9 @@ func newRepoCatCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+		service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/"))
 
-			content, err := service.Raw(cmd.Context(), repo, args[0], at)
+		content, err := service.Raw(cmd.Context(), repo, args[0], at)
 			if err != nil {
 				return err
 			}
@@ -78,9 +80,9 @@ func newRepoEditCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+		service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/"))
 
-			if options.DryRun {
+		if options.DryRun {
 				checker := options.permissionCheckerFor(client)
 				if err := checker.CheckRepoPermission(cmd.Context(), repo.ProjectKey, repo.Slug, openapigenerated.REPOWRITE); err != nil {
 					return err

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -54,6 +54,8 @@ func AllSpecs() []Spec {
 		// Opening a PR is low-blast-radius and easily closed — safe by default.
 		{specCreatePullRequest().Tool, specCreatePullRequest().Handler, true},
 		{specListPRComments().Tool, specListPRComments().Handler, true},
+		{specGetPRDiff().Tool, specGetPRDiff().Handler, true},
+		{specGetFileContent().Tool, specGetFileContent().Handler, true},
 		// Adding a comment is trivially reversed — safe by default.
 		{specAddPRComment().Tool, specAddPRComment().Handler, true},
 		{specListPRTasks().Tool, specListPRTasks().Handler, true},

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -41,7 +41,7 @@ func testClients(t *testing.T) Clients {
 
 // TestAllSpecsReturnsExpectedCount ensures the catalog has exactly the expected number of tools.
 func TestAllSpecsReturnsExpectedCount(t *testing.T) {
-	const wantCount = 22
+	const wantCount = 24
 	specs := AllSpecs()
 	if len(specs) != wantCount {
 		t.Errorf("AllSpecs: got %d tools, want %d", len(specs), wantCount)
@@ -254,6 +254,8 @@ func TestToolNamesMatchExpected(t *testing.T) {
 		"list_pull_requests",
 		"create_pull_request",
 		"list_pr_comments",
+		"get_pr_diff",
+		"get_file_content",
 		"add_pr_comment",
 		"list_pr_tasks",
 		"submit_pr_review",

--- a/internal/mcp/tools_pr.go
+++ b/internal/mcp/tools_pr.go
@@ -8,7 +8,9 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
+	browseservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/browse"
 	commentservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/comment"
+	diffservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/diff"
 	pullrequestservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/pullrequest"
 	pullrequestactivityservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/pullrequestactivity"
 )
@@ -37,30 +39,49 @@ func specGetPullRequest() Spec {
 
 func specListPullRequests() Spec {
 	tool := mcpgo.NewTool("list_pull_requests",
-		mcpgo.WithDescription("List pull requests for a repository. Defaults to OPEN state."),
-		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
-		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
+		mcpgo.WithDescription("List pull requests. Without project/repo, lists the current user's PRs across all repositories (dashboard)."),
+		mcpgo.WithString("project", mcpgo.Description("Bitbucket project key (omit for dashboard mode)")),
+		mcpgo.WithString("repo", mcpgo.Description("Repository slug (omit for dashboard mode)")),
 		mcpgo.WithString("state", mcpgo.Description("Filter by state: OPEN (default), MERGED, DECLINED, ALL")),
-		mcpgo.WithString("source_branch", mcpgo.Description("Filter by source branch name")),
-		mcpgo.WithString("target_branch", mcpgo.Description("Filter by target branch name")),
+		mcpgo.WithString("role", mcpgo.Description("Filter by role: REVIEWER, AUTHOR, or PARTICIPANT (works in both repo and dashboard mode)")),
+		mcpgo.WithString("source_branch", mcpgo.Description("Filter by source branch name (repo mode only)")),
+		mcpgo.WithString("target_branch", mcpgo.Description("Filter by target branch name (repo mode only)")),
 		mcpgo.WithNumber("limit", mcpgo.Description("Maximum number of results (default 25)")),
 	)
 	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
 		svc := pullrequestservice.NewService(c.HTTP)
 		return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-			project, _ := req.RequireString("project")
-			repo, _ := req.RequireString("repo")
-			opts := pullrequestservice.ListOptions{
-				State:        req.GetString("state", "OPEN"),
-				SourceBranch: req.GetString("source_branch", ""),
-				TargetBranch: req.GetString("target_branch", ""),
-				Limit:        req.GetInt("limit", 25),
+			project := req.GetString("project", "")
+			repo := req.GetString("repo", "")
+			state := req.GetString("state", "OPEN")
+			limit := req.GetInt("limit", 25)
+
+			var prs []pullrequestservice.PullRequest
+			var err error
+
+			if project != "" && repo != "" {
+				opts := pullrequestservice.ListOptions{
+					State:        state,
+					Role:         req.GetString("role", ""),
+					SourceBranch: req.GetString("source_branch", ""),
+					TargetBranch: req.GetString("target_branch", ""),
+					Limit:        limit,
+				}
+				prs, err = svc.List(ctx, pullrequestservice.RepositoryRef{ProjectKey: project, Slug: repo}, opts)
+			} else if project != "" || repo != "" {
+				return mcpgo.NewToolResultError("list_pull_requests requires both project and repo, or neither for dashboard mode"), nil
+			} else {
+				opts := pullrequestservice.DashboardListOptions{
+					State: state,
+					Role:  req.GetString("role", "REVIEWER"),
+					Limit: limit,
+				}
+				prs, err = svc.ListDashboard(ctx, opts)
 			}
-			prs, err := svc.List(ctx, pullrequestservice.RepositoryRef{ProjectKey: project, Slug: repo}, opts)
 			if err != nil {
 				return mcpgo.NewToolResultErrorFromErr("list_pull_requests failed", err), nil
 			}
-			return resultJSON(prs)
+			return resultJSON(map[string]any{"pull_requests": prs})
 		}
 	}}
 }
@@ -146,24 +167,40 @@ func specListPRComments() Spec {
 
 func specAddPRComment() Spec {
 	tool := mcpgo.NewTool("add_pr_comment",
-		mcpgo.WithDescription("Add a comment to a pull request."),
+		mcpgo.WithDescription("Add a comment to a pull request. Provide path and line to create an inline comment on a specific file line. Provide parent_id to reply to an existing comment."),
 		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
 		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
 		mcpgo.WithString("pr_id", mcpgo.Required(), mcpgo.Description("Pull request ID")),
 		mcpgo.WithString("text", mcpgo.Required(), mcpgo.Description("Comment text (Markdown supported)")),
+		mcpgo.WithString("path", mcpgo.Description("File path for inline comment (e.g. src/main.go)")),
+		mcpgo.WithNumber("line", mcpgo.Description("Line number for inline comment")),
+		mcpgo.WithString("line_type", mcpgo.Description("Diff side for inline comment: ADDED (default), REMOVED, or CONTEXT")),
+		mcpgo.WithNumber("parent_id", mcpgo.Description("Parent comment ID to reply to")),
 	)
 	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
-		svc := commentservice.NewService(c.OpenAPI)
+		svc := pullrequestservice.NewService(c.HTTP)
 		return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 			project, _ := req.RequireString("project")
 			repo, _ := req.RequireString("repo")
 			prID, _ := req.RequireString("pr_id")
 			text, _ := req.RequireString("text")
-			target := commentservice.Target{
-				Repository:    commentservice.RepositoryRef{ProjectKey: project, Slug: repo},
-				PullRequestID: prID,
+			filePath := req.GetString("path", "")
+			line := req.GetInt("line", 0)
+			ref := pullrequestservice.RepositoryRef{ProjectKey: project, Slug: repo}
+			var comment pullrequestservice.Comment
+			var err error
+			if filePath != "" && line > 0 {
+				comment, err = svc.AddInlineComment(ctx, ref, prID, text,
+					pullrequestservice.InlineCommentAnchor{
+						Line:     line,
+						Path:    filePath,
+						LineType: req.GetString("line_type", "ADDED"),
+					},
+				)
+			} else {
+				parentID := int64(req.GetInt("parent_id", 0))
+				comment, err = svc.AddComment(ctx, ref, prID, text, parentID)
 			}
-			comment, err := svc.Create(ctx, target, text)
 			if err != nil {
 				return mcpgo.NewToolResultErrorFromErr("add_pr_comment failed", err), nil
 			}
@@ -205,12 +242,12 @@ func specListPRTasks() Spec {
 
 func specSubmitPRReview() Spec {
 	tool := mcpgo.NewTool("submit_pr_review",
-		mcpgo.WithDescription("Approve or unapprove a pull request."),
+		mcpgo.WithDescription("Set review status on a pull request: approve, unapprove, or request changes (needs_work)."),
 		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
 		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
 		mcpgo.WithString("pr_id", mcpgo.Required(), mcpgo.Description("Pull request ID")),
-		mcpgo.WithString("action", mcpgo.Required(), mcpgo.Description("Action to take: approve or unapprove"),
-			mcpgo.Enum("approve", "unapprove")),
+		mcpgo.WithString("action", mcpgo.Required(), mcpgo.Description("Action to take: approve, unapprove, or needs_work"),
+			mcpgo.Enum("approve", "unapprove", "needs_work")),
 	)
 	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
 		svc := pullrequestservice.NewService(c.HTTP)
@@ -227,6 +264,8 @@ func specSubmitPRReview() Spec {
 				pr, err = svc.Approve(ctx, ref, prID)
 			case "unapprove":
 				pr, err = svc.Unapprove(ctx, ref, prID)
+			case "needs_work":
+				pr, err = svc.NeedsWork(ctx, ref, prID)
 			default:
 				return mcpgo.NewToolResultErrorFromErr("submit_pr_review: unknown action "+strconv.Quote(action), nil), nil
 			}
@@ -338,4 +377,54 @@ func parseCommaList(s string) []string {
 		return nil
 	}
 	return result
+}
+
+func specGetPRDiff() Spec {
+	tool := mcpgo.NewTool("get_pr_diff",
+		mcpgo.WithDescription("Get the diff of a pull request as unified diff text."),
+		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
+		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
+		mcpgo.WithString("pr_id", mcpgo.Required(), mcpgo.Description("Pull request ID")),
+	)
+	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
+		svc := diffservice.NewService(c.OpenAPI)
+		return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			project, _ := req.RequireString("project")
+			repo, _ := req.RequireString("repo")
+			prID, _ := req.RequireString("pr_id")
+			result, err := svc.DiffPR(ctx, diffservice.DiffPRInput{
+				Repository:    diffservice.RepositoryRef{ProjectKey: project, Slug: repo},
+				PullRequestID: prID,
+				Output:        diffservice.OutputKindRaw,
+			})
+			if err != nil {
+				return mcpgo.NewToolResultErrorFromErr("get_pr_diff failed", err), nil
+			}
+			return resultJSON(result)
+		}
+	}}
+}
+
+func specGetFileContent() Spec {
+	tool := mcpgo.NewTool("get_file_content",
+		mcpgo.WithDescription("Get the raw content of a file in a repository."),
+		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
+		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
+		mcpgo.WithString("path", mcpgo.Required(), mcpgo.Description("File path in the repository")),
+		mcpgo.WithString("at", mcpgo.Description("Git ref or branch to read from (e.g. refs/heads/main)")),
+	)
+	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
+		svc := browseservice.NewService(c.OpenAPI, c.HTTP, c.BaseURL)
+		return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			project, _ := req.RequireString("project")
+			repo, _ := req.RequireString("repo")
+			path, _ := req.RequireString("path")
+			at := req.GetString("at", "")
+			content, err := svc.Raw(ctx, browseservice.RepositoryRef{ProjectKey: project, Slug: repo}, path, at)
+			if err != nil {
+				return mcpgo.NewToolResultErrorFromErr("get_file_content failed", err), nil
+			}
+			return mcpgo.NewToolResultText(string(content)), nil
+		}
+	}}
 }

--- a/internal/services/browse/service.go
+++ b/internal/services/browse/service.go
@@ -3,12 +3,14 @@ package browse
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"mime/multipart"
 	"strings"
 
 	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
 	"github.com/vriesdemichael/bitbucket-server-cli/internal/openapi"
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
 )
 
 type RepositoryRef struct {
@@ -35,11 +37,13 @@ type EditInput struct {
 }
 
 type Service struct {
-	client *openapigenerated.ClientWithResponses
+	client  *openapigenerated.ClientWithResponses
+	http    *httpclient.Client
+	baseURL string
 }
 
-func NewService(client *openapigenerated.ClientWithResponses) *Service {
-	return &Service{client: client}
+func NewService(client *openapigenerated.ClientWithResponses, http *httpclient.Client, baseURL string) *Service {
+	return &Service{client: client, http: http, baseURL: baseURL}
 }
 
 func (service *Service) Tree(ctx context.Context, repo RepositoryRef, path string, options TreeOptions) ([]string, error) {
@@ -135,23 +139,16 @@ func (service *Service) Raw(ctx context.Context, repo RepositoryRef, path string
 		return nil, apperrors.New(apperrors.KindValidation, "path is required", nil)
 	}
 
-	var atParam *string
+	// The OpenAPI generated client URL-encodes "/" in the path parameter to "%2F",
+	// but Bitbucket Server's /raw/{path} endpoint expects "/" as a real URL path
+	// separator. Use httpclient.GetRaw directly to construct the correct URL.
+	apiPath := fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/raw/%s", repo.ProjectKey, repo.Slug, trimmedPath)
+	query := map[string]string{}
 	if strings.TrimSpace(at) != "" {
-		a := strings.TrimSpace(at)
-		atParam = &a
+		query["at"] = strings.TrimSpace(at)
 	}
 
-	params := &openapigenerated.StreamRawParams{At: atParam}
-	resp, err := service.client.StreamRawWithResponse(ctx, repo.ProjectKey, repo.Slug, trimmedPath, params)
-	if err != nil {
-		return nil, apperrors.New(apperrors.KindTransient, "failed to get raw content", err)
-	}
-
-	if err := openapi.MapStatusError(resp.StatusCode(), resp.Body); err != nil {
-		return nil, err
-	}
-
-	return resp.Body, nil
+	return service.http.GetRaw(ctx, apiPath, query)
 }
 
 func (service *Service) File(ctx context.Context, repo RepositoryRef, path string, options FileOptions) ([]byte, error) {
@@ -162,6 +159,20 @@ func (service *Service) File(ctx context.Context, repo RepositoryRef, path strin
 	trimmedPath := strings.TrimSpace(path)
 	if trimmedPath == "" {
 		return nil, apperrors.New(apperrors.KindValidation, "path is required", nil)
+	}
+
+	// Same issue as Raw: generated client URL-encodes "/" in path.
+	// Use httpclient.GetRaw for paths containing "/".
+	if strings.Contains(trimmedPath, "/") {
+		apiPath := fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/browse/%s", repo.ProjectKey, repo.Slug, trimmedPath)
+		query := map[string]string{}
+		if strings.TrimSpace(options.At) != "" {
+			query["at"] = strings.TrimSpace(options.At)
+		}
+		if options.Blame {
+			query["blame"] = "true"
+		}
+		return service.http.GetRaw(ctx, apiPath, query)
 	}
 
 	var atParam *string

--- a/internal/services/browse/service_test.go
+++ b/internal/services/browse/service_test.go
@@ -2,14 +2,17 @@ package browse
 
 import (
 	"context"
-	"github.com/vriesdemichael/bitbucket-server-cli/internal/openapi"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/openapi"
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/config"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
 )
 
 func newBrowseTestService(t *testing.T, handler http.HandlerFunc) *Service {
@@ -22,7 +25,15 @@ func newBrowseTestService(t *testing.T, handler http.HandlerFunc) *Service {
 		t.Fatalf("create client: %v", err)
 	}
 
-	return NewService(client)
+	// Build a minimal httpclient.Client for tests using exported constructor.
+	// The config doesn't need real credentials for httptest.
+	cfg := config.AppConfig{
+		BitbucketURL:    server.URL,
+		RequestTimeout:  10 * time.Second,
+		RetryCount:      0,
+	}
+	httpClient := httpclient.NewFromConfig(cfg)
+	return NewService(client, httpClient, strings.TrimRight(server.URL, "/"))
 }
 
 func TestBrowseServiceCoreCommands(t *testing.T) {

--- a/internal/services/pullrequest/service.go
+++ b/internal/services/pullrequest/service.go
@@ -25,6 +25,7 @@ type ListOptions struct {
 	Start        int    `json:"start"`
 	SourceBranch string `json:"source_branch,omitempty"`
 	TargetBranch string `json:"target_branch,omitempty"`
+	Role         string `json:"role,omitempty"`
 }
 
 type PullRequest struct {
@@ -226,6 +227,9 @@ func (service *Service) List(ctx context.Context, repository RepositoryRef, opti
 		} else {
 			query["state"] = "ALL"
 		}
+		if options.Role != "" {
+			query["role"] = strings.ToUpper(options.Role)
+		}
 
 		var response pagedPullRequestResponse
 		if err := service.client.GetJSON(ctx, path, query, &response); err != nil {
@@ -389,6 +393,119 @@ func (service *Service) Unapprove(ctx context.Context, repository RepositoryRef,
 	}
 
 	return mapPullRequest(response), nil
+}
+
+// NeedsWork sets the current user's review status to NEEDS_WORK on a pull request.
+// Uses PUT .../participants/{userSlug} with {"status": "NEEDS_WORK"}.
+// The userSlug is resolved by posting a temporary comment and reading the author from the response.
+func (service *Service) NeedsWork(ctx context.Context, repository RepositoryRef, pullRequestID string) (PullRequest, error) {
+	if err := validateRepositoryRef(repository); err != nil {
+		return PullRequest{}, err
+	}
+
+	resolvedID, err := normalizePullRequestID(pullRequestID)
+	if err != nil {
+		return PullRequest{}, err
+	}
+
+	userSlug, err := service.client.CurrentUserSlug(ctx)
+	if err != nil {
+		return PullRequest{}, err
+	}
+
+	path := fmt.Sprintf("%s/%s/participants/%s", pullRequestPath(repository), resolvedID, url.PathEscape(userSlug))
+	payload := map[string]any{"status": "NEEDS_WORK"}
+
+	var response pullRequestValue
+	if err := service.client.PutJSON(ctx, path, nil, payload, &response); err != nil {
+		return PullRequest{}, err
+	}
+
+	return mapPullRequest(response), nil
+}
+
+// InlineCommentAnchor specifies the file location for an inline PR comment.
+type InlineCommentAnchor struct {
+	Line     int    `json:"line"`
+	Path    string `json:"path"`
+	LineType string `json:"lineType"` // ADDED, REMOVED, or CONTEXT
+}
+
+// Comment represents a pull request comment returned by the API.
+type Comment struct {
+	ID      int64  `json:"id"`
+	Version int    `json:"version"`
+	Text    string `json:"text"`
+	Author  struct {
+		Name        string `json:"name"`
+		DisplayName string `json:"displayName"`
+		Slug        string `json:"slug"`
+	} `json:"author"`
+}
+
+// AddComment adds a general comment to a pull request.
+// If parentID > 0, the comment is posted as a reply to that comment.
+func (service *Service) AddComment(ctx context.Context, repository RepositoryRef, pullRequestID string, text string, parentID int64) (Comment, error) {
+	if err := validateRepositoryRef(repository); err != nil {
+		return Comment{}, err
+	}
+	resolvedID, err := normalizePullRequestID(pullRequestID)
+	if err != nil {
+		return Comment{}, err
+	}
+	trimmedText := strings.TrimSpace(text)
+	if trimmedText == "" {
+		return Comment{}, apperrors.New(apperrors.KindValidation, "comment text is required", nil)
+	}
+	path := fmt.Sprintf("%s/%s/comments", pullRequestPath(repository), resolvedID)
+	payload := map[string]any{"text": trimmedText}
+	if parentID > 0 {
+		payload["parent"] = map[string]any{"id": parentID}
+	}
+	var result Comment
+	if err := service.client.PostJSON(ctx, path, nil, payload, &result); err != nil {
+		return Comment{}, err
+	}
+	return result, nil
+}
+
+// AddInlineComment adds a comment on a specific line of a file in a pull request diff.
+func (service *Service) AddInlineComment(ctx context.Context, repository RepositoryRef, pullRequestID string, text string, anchor InlineCommentAnchor) (Comment, error) {
+	if err := validateRepositoryRef(repository); err != nil {
+		return Comment{}, err
+	}
+	resolvedID, err := normalizePullRequestID(pullRequestID)
+	if err != nil {
+		return Comment{}, err
+	}
+	trimmedText := strings.TrimSpace(text)
+	if trimmedText == "" {
+		return Comment{}, apperrors.New(apperrors.KindValidation, "comment text is required", nil)
+	}
+	if anchor.Path == "" {
+		return Comment{}, apperrors.New(apperrors.KindValidation, "file path is required for inline comments", nil)
+	}
+	if anchor.Line <= 0 {
+		return Comment{}, apperrors.New(apperrors.KindValidation, "line must be a positive integer", nil)
+	}
+	lineType := strings.ToUpper(strings.TrimSpace(anchor.LineType))
+	if lineType == "" {
+		lineType = "ADDED"
+	}
+	path := fmt.Sprintf("%s/%s/comments", pullRequestPath(repository), resolvedID)
+	payload := map[string]any{
+		"text": trimmedText,
+		"anchor": map[string]any{
+			"line":     anchor.Line,
+			"path":    anchor.Path,
+			"lineType": lineType,
+		},
+	}
+	var result Comment
+	if err := service.client.PostJSON(ctx, path, nil, payload, &result); err != nil {
+		return Comment{}, err
+	}
+	return result, nil
 }
 
 func (service *Service) AddReviewer(ctx context.Context, repository RepositoryRef, pullRequestID string, username string) (PullRequest, error) {
@@ -796,7 +913,7 @@ func mapPullRequest(raw pullRequestValue) PullRequest {
 		SourceCommit: sourceCommit(raw.FromRef),
 		CreatedDate:  raw.CreatedDate,
 		UpdatedDate:  raw.UpdatedDate,
-		Reviewers:    mapReviewers(raw.Participants),
+		Reviewers:    mapReviewers(raw.Participants, raw.Reviewers),
 	}
 
 	if raw.ToRef != nil && raw.ToRef.Repository != nil {
@@ -809,13 +926,21 @@ func mapPullRequest(raw pullRequestValue) PullRequest {
 	return pr
 }
 
-func mapReviewers(participants []pullRequestParticipant) []Reviewer {
-	if len(participants) == 0 {
+// mapReviewers maps PR participants to reviewers. On Bitbucket Data Center 9.4.16,
+// the PR response "participants" field is always empty; only "reviewers" contains
+// the assigned reviewers with their approval status. Falls back to "reviewers"
+// when "participants" is empty. Filters out role=="author" as a safety net.
+func mapReviewers(participants []pullRequestParticipant, reviewers []pullRequestParticipant) []Reviewer {
+	raw := participants
+	if len(raw) == 0 {
+		raw = reviewers
+	}
+	if len(raw) == 0 {
 		return nil
 	}
 
-	reviewers := make([]Reviewer, 0, len(participants))
-	for _, participant := range participants {
+	result := make([]Reviewer, 0, len(raw))
+	for _, participant := range raw {
 		if participant.User == nil {
 			continue
 		}
@@ -833,14 +958,14 @@ func mapReviewers(participants []pullRequestParticipant) []Reviewer {
 			continue
 		}
 
-		reviewers = append(reviewers, reviewer)
+		result = append(result, reviewer)
 	}
 
-	if len(reviewers) == 0 {
+	if len(result) == 0 {
 		return nil
 	}
 
-	return reviewers
+	return result
 }
 
 func mapMergeability(raw mergeabilityValue) Mergeability {
@@ -1155,6 +1280,7 @@ type pullRequestValue struct {
 	UpdatedDate  int64                    `json:"updatedDate"`
 	Author       *pullRequestUser         `json:"author"`
 	Participants []pullRequestParticipant `json:"participants"`
+	Reviewers    []pullRequestParticipant `json:"reviewers"`
 	FromRef      *pullRequestRef          `json:"fromRef"`
 	ToRef        *pullRequestRef          `json:"toRef"`
 }

--- a/internal/services/pullrequest/service_test.go
+++ b/internal/services/pullrequest/service_test.go
@@ -175,7 +175,7 @@ func TestPullRequestLifecycleReviewAndTaskOperations(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		switch {
 		case request.Method == http.MethodGet && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/22":
-			_, _ = fmt.Fprint(w, `{"id":22,"title":"Feature","state":"OPEN","open":true,"closed":false,"version":2,"participants":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1","displayName":"Reviewer One"}}],"fromRef":{"displayId":"feature/a"},"toRef":{"displayId":"master"}}`)
+			_, _ = fmt.Fprint(w, `{"id":22,"title":"Feature","state":"OPEN","open":true,"closed":false,"version":2,"reviewers":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1","displayName":"Reviewer One"}}],"fromRef":{"displayId":"feature/a"},"toRef":{"displayId":"master"}}`)
 		case request.Method == http.MethodGet && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/22/merge":
 			_, _ = fmt.Fprint(w, `{"conflicted":false,"outcome":"CLEAN","vetoes":[]}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests":
@@ -199,13 +199,13 @@ func TestPullRequestLifecycleReviewAndTaskOperations(t *testing.T) {
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/reopen":
 			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/approve":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"APPROVED","approved":true,"user":{"name":"reviewer1"}}]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[{"role":"REVIEWER","status":"APPROVED","approved":true,"user":{"name":"reviewer1"}}]}`)
 		case request.Method == http.MethodDelete && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/approve":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1"}}]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1"}}]}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer2"}}]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer2"}}]}`)
 		case request.Method == http.MethodDelete && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants/reviewer2":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[]}`)
 		case request.Method == http.MethodGet && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/tasks":
 			_, _ = fmt.Fprint(w, `{"isLastPage":true,"nextPageStart":0,"values":[{"id":500,"text":"Open task","state":"OPEN","resolved":false},{"id":501,"text":"Resolved task","state":"RESOLVED","resolved":true}]}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/tasks":

--- a/internal/transport/httpclient/client.go
+++ b/internal/transport/httpclient/client.go
@@ -69,6 +69,39 @@ func (client *Client) GetJSON(ctx context.Context, path string, query map[string
 	return client.doJSON(ctx, http.MethodGet, path, query, nil, out)
 }
 
+// CurrentUserSlug returns the authenticated user's slug by reading the
+// X-AUSERNAME response header from a lightweight API request.
+func (client *Client) CurrentUserSlug(ctx context.Context) (string, error) {
+	if client.initErr != nil {
+		return "", apperrors.New(apperrors.KindValidation, "failed to initialize HTTP transport", client.initErr)
+	}
+
+	requestURL, err := url.Parse(client.baseURL + "/rest/api/latest/users")
+	if err != nil {
+		return "", apperrors.New(apperrors.KindValidation, "invalid request URL", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return "", apperrors.New(apperrors.KindInternal, "failed to build request", err)
+	}
+	request.Header.Set("Accept", "application/json")
+	client.applyAuth(request)
+
+	response, err := client.http.Do(request)
+	if err != nil {
+		return "", apperrors.New(apperrors.KindTransient, "request failed", err)
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, response.Body)
+
+	slug := strings.TrimSpace(response.Header.Get("X-AUSERNAME"))
+	if slug == "" {
+		return "", apperrors.New(apperrors.KindAuthentication, "X-AUSERNAME header not found in response", nil)
+	}
+	return slug, nil
+}
+
 func (client *Client) PostJSON(ctx context.Context, path string, query map[string]string, in any, out any) error {
 	return client.doJSON(ctx, http.MethodPost, path, query, in, out)
 }
@@ -79,6 +112,108 @@ func (client *Client) PutJSON(ctx context.Context, path string, query map[string
 
 func (client *Client) DeleteJSON(ctx context.Context, path string, query map[string]string, in any, out any) error {
 	return client.doJSON(ctx, http.MethodDelete, path, query, in, out)
+}
+
+// GetRaw performs a GET request and returns the raw response body as bytes.
+// Unlike GetJSON, it does not set Accept: application/json or attempt to unmarshal.
+func (client *Client) GetRaw(ctx context.Context, path string, query map[string]string) ([]byte, error) {
+	if client.initErr != nil {
+		return nil, apperrors.New(apperrors.KindValidation, "failed to initialize HTTP transport", client.initErr)
+	}
+
+	requestURL, err := url.Parse(client.baseURL + path)
+	if err != nil {
+		return nil, apperrors.New(apperrors.KindValidation, "invalid request URL", err)
+	}
+
+	values := requestURL.Query()
+	for key, value := range query {
+		values.Set(key, value)
+	}
+	requestURL.RawQuery = values.Encode()
+
+	var lastErr error
+	for attempt := 0; attempt <= client.retries; attempt++ {
+		started := time.Now()
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+		if err != nil {
+			return nil, apperrors.New(apperrors.KindInternal, "failed to build request", err)
+		}
+		client.applyAuth(request)
+
+		response, err := client.http.Do(request)
+		if err != nil {
+			fields := map[string]any{
+				"method":      http.MethodGet,
+				"endpoint":    requestURL.Path,
+				"attempt":     attempt + 1,
+				"retry_count": client.retries,
+				"duration_ms": time.Since(started).Milliseconds(),
+				"error":       err.Error(),
+			}
+			lastErr = apperrors.New(apperrors.KindTransient, "request failed", err)
+			if attempt < client.retries {
+				client.logger.Warn("http request failed", fields)
+				if sleepErr := sleepWithContext(ctx, time.Duration(attempt+1)*client.backoff); sleepErr != nil {
+					return nil, apperrors.New(apperrors.KindTransient, "request canceled while waiting to retry", sleepErr)
+				}
+				continue
+			}
+			client.logger.Error("http request failed", fields)
+			return nil, lastErr
+		}
+
+		body, readErr := io.ReadAll(response.Body)
+		_ = response.Body.Close()
+		if readErr != nil {
+			return nil, apperrors.New(apperrors.KindTransient, "failed to read response", readErr)
+		}
+
+		if response.StatusCode >= 200 && response.StatusCode < 300 {
+			client.logger.Debug("http request completed", map[string]any{
+				"method":      http.MethodGet,
+				"endpoint":    requestURL.Path,
+				"status":      response.StatusCode,
+				"attempt":     attempt + 1,
+				"retry_count": client.retries,
+				"duration_ms": time.Since(started).Milliseconds(),
+			})
+			return body, nil
+		}
+
+		mappedErr := openapi.MapStatusError(response.StatusCode, body)
+		fields := map[string]any{
+			"method":      http.MethodGet,
+			"endpoint":    requestURL.Path,
+			"status":      response.StatusCode,
+			"attempt":     attempt + 1,
+			"retry_count": client.retries,
+			"duration_ms": time.Since(started).Milliseconds(),
+			"error":       mappedErr.Error(),
+		}
+		if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
+			lastErr = mappedErr
+			retryDelay := retryDelayFromResponse(response.Header, attempt, client.backoff)
+			fields["retry_delay"] = retryDelay.String()
+			if attempt < client.retries {
+				client.logger.Warn("http request returned error status", fields)
+				if sleepErr := sleepWithContext(ctx, retryDelay); sleepErr != nil {
+					return nil, apperrors.New(apperrors.KindTransient, "request canceled while waiting to retry", sleepErr)
+				}
+				continue
+			}
+			client.logger.Error("http request returned error status", fields)
+			return nil, lastErr
+		}
+
+		client.logger.Error("http request returned error status", fields)
+		return nil, mappedErr
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, apperrors.New(apperrors.KindTransient, "request failed after retries", nil)
 }
 
 func (client *Client) doJSON(ctx context.Context, method string, path string, query map[string]string, in any, out any) error {


### PR DESCRIPTION
## Summary

- Add `httpclient.GetRaw` and `CurrentUserSlug` methods (use `X-AUSERNAME` response header instead of temp-comment hack)
- Fix browse raw/file commands: bypass OpenAPI client URL-encoding of `/` in file paths
- Add MCP tools: `get_pr_diff`, `get_file_content`
- Enhance MCP `list_pull_requests`: dashboard mode, role filter, validate project/repo params
- Enhance MCP `add_pr_comment`: inline comments (path/line) and replies (parent_id)
- Enhance MCP `submit_pr_review`: add `needs_work` action
- Add PR service methods: `NeedsWork`, `AddComment`, `AddInlineComment`
- Use `reviewers` field with `participants` fallback for PR reviewer data (tested on Bitbucket Data Center 9.4.16 where `participants` is always empty)
- Remove unnecessary `withAttributes=true` query parameter from PR Get
- Add `bb.exe` to `.gitignore`