### PR TITLE
feat: MCP tool enhancements and browse path-encoding fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ __pycache__/
 !/.tmp/.gitkeep
 # Generated Windows PE resource files (created by go-winres during CI builds)
 cmd/bb/rsrc_windows_*.syso
+# Local build artifacts
+bb.exe

--- a/docs/quality/spec-coverage.json
+++ b/docs/quality/spec-coverage.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
   "spec": "docs/reference/atlassian/bitbucket-9.4-openapi.json",
-  "covered": 226,
+  "covered": 223,
   "total": 546,
-  "coverage_percent": 41.39194139194139,
+  "coverage_percent": 40.84249084249084,
   "by_tag": [
     {
       "tag": "",
@@ -67,12 +67,12 @@
     },
     {
       "tag": "Pull Requests",
-      "covered": 59,
+      "covered": 60,
       "total": 69
     },
     {
       "tag": "Repository",
-      "covered": 67,
+      "covered": 63,
       "total": 96
     },
     {
@@ -875,6 +875,12 @@
     },
     {
       "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/browse/{path}",
+      "tag": "Repository",
+      "summary": "Get file content"
+    },
+    {
+      "method": "GET",
       "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/changes",
       "tag": "Repository",
       "summary": "Get changes made in commit"
@@ -926,6 +932,18 @@
       "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/diff",
       "tag": "Repository",
       "summary": "Get raw diff for path"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/files",
+      "tag": "Repository",
+      "summary": "Get files in directory"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/files/{path}",
+      "tag": "Repository",
+      "summary": "Get files in directory"
     },
     {
       "method": "GET",
@@ -1000,12 +1018,6 @@
       "summary": "Get pull request participants"
     },
     {
-      "method": "PUT",
-      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/participants/{userSlug}",
-      "tag": "Pull Requests",
-      "summary": "Change pull request status"
-    },
-    {
       "method": "DELETE",
       "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/review",
       "tag": "Pull Requests",
@@ -1022,6 +1034,12 @@
       "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/review",
       "tag": "Pull Requests",
       "summary": "Complete pull request review"
+    },
+    {
+      "method": "GET",
+      "path": "/api/latest/projects/{projectKey}/repos/{repositorySlug}/raw/{path}",
+      "tag": "Repository",
+      "summary": "Get raw content of a file at revision"
     },
     {
       "method": "GET",

--- a/internal/cli/browse.go
+++ b/internal/cli/browse.go
@@ -9,6 +9,7 @@ import (
 	browseservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/browse"
 	commitservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/commit"
 	"github.com/vriesdemichael/bitbucket-server-cli/internal/cli/style"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
 )
 
 func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
@@ -39,7 +40,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
 
 			path := ""
 			if len(args) > 0 {
@@ -91,7 +92,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
 
 			content, err := service.Raw(cmd.Context(), repo, args[0], rawAt)
 			if err != nil {
@@ -123,7 +124,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
 
 			content, err := service.File(cmd.Context(), repo, args[0], browseservice.FileOptions{
 				At:    fileAt,
@@ -180,7 +181,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
 
 			content, err := service.File(cmd.Context(), repo, args[0], browseservice.FileOptions{
 				At:    blameAt,

--- a/internal/cli/browse.go
+++ b/internal/cli/browse.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/cli/style"
 	browseservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/browse"
 	commitservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/commit"
-	"github.com/vriesdemichael/bitbucket-server-cli/internal/cli/style"
 	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
 )
 
@@ -40,7 +40,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg))
 
 			path := ""
 			if len(args) > 0 {
@@ -92,7 +92,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg))
 
 			content, err := service.Raw(cmd.Context(), repo, args[0], rawAt)
 			if err != nil {
@@ -124,7 +124,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg))
 
 			content, err := service.File(cmd.Context(), repo, args[0], browseservice.FileOptions{
 				At:    fileAt,
@@ -181,7 +181,7 @@ func newRepoBrowseCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/" ))
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg))
 
 			content, err := service.File(cmd.Context(), repo, args[0], browseservice.FileOptions{
 				At:    blameAt,

--- a/internal/cli/repo_cat_edit.go
+++ b/internal/cli/repo_cat_edit.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
 	browseservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/browse"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
 )
 
 func newRepoCatCommand(options *rootOptions) *cobra.Command {
@@ -28,9 +30,9 @@ func newRepoCatCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+		service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/"))
 
-			content, err := service.Raw(cmd.Context(), repo, args[0], at)
+		content, err := service.Raw(cmd.Context(), repo, args[0], at)
 			if err != nil {
 				return err
 			}
@@ -78,9 +80,9 @@ func newRepoEditCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-			service := browseservice.NewService(client)
+		service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/"))
 
-			if options.DryRun {
+		if options.DryRun {
 				checker := options.permissionCheckerFor(client)
 				if err := checker.CheckRepoPermission(cmd.Context(), repo.ProjectKey, repo.Slug, openapigenerated.REPOWRITE); err != nil {
 					return err

--- a/internal/cli/repo_cat_edit.go
+++ b/internal/cli/repo_cat_edit.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
@@ -30,9 +29,9 @@ func newRepoCatCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-		service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/"))
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg))
 
-		content, err := service.Raw(cmd.Context(), repo, args[0], at)
+			content, err := service.Raw(cmd.Context(), repo, args[0], at)
 			if err != nil {
 				return err
 			}
@@ -80,9 +79,9 @@ func newRepoEditCommand(options *rootOptions) *cobra.Command {
 			}
 
 			repo := browseservice.RepositoryRef{ProjectKey: repoRef.ProjectKey, Slug: repoRef.Slug}
-		service := browseservice.NewService(client, httpclient.NewFromConfig(cfg), strings.TrimRight(cfg.BitbucketURL, "/"))
+			service := browseservice.NewService(client, httpclient.NewFromConfig(cfg))
 
-		if options.DryRun {
+			if options.DryRun {
 				checker := options.permissionCheckerFor(client)
 				if err := checker.CheckRepoPermission(cmd.Context(), repo.ProjectKey, repo.Slug, openapigenerated.REPOWRITE); err != nil {
 					return err

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -54,6 +54,8 @@ func AllSpecs() []Spec {
 		// Opening a PR is low-blast-radius and easily closed — safe by default.
 		{specCreatePullRequest().Tool, specCreatePullRequest().Handler, true},
 		{specListPRComments().Tool, specListPRComments().Handler, true},
+		{specGetPRDiff().Tool, specGetPRDiff().Handler, true},
+		{specGetFileContent().Tool, specGetFileContent().Handler, true},
 		// Adding a comment is trivially reversed — safe by default.
 		{specAddPRComment().Tool, specAddPRComment().Handler, true},
 		{specListPRTasks().Tool, specListPRTasks().Handler, true},

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -41,7 +41,7 @@ func testClients(t *testing.T) Clients {
 
 // TestAllSpecsReturnsExpectedCount ensures the catalog has exactly the expected number of tools.
 func TestAllSpecsReturnsExpectedCount(t *testing.T) {
-	const wantCount = 22
+	const wantCount = 24
 	specs := AllSpecs()
 	if len(specs) != wantCount {
 		t.Errorf("AllSpecs: got %d tools, want %d", len(specs), wantCount)
@@ -254,6 +254,8 @@ func TestToolNamesMatchExpected(t *testing.T) {
 		"list_pull_requests",
 		"create_pull_request",
 		"list_pr_comments",
+		"get_pr_diff",
+		"get_file_content",
 		"add_pr_comment",
 		"list_pr_tasks",
 		"submit_pr_review",

--- a/internal/mcp/tools_pr.go
+++ b/internal/mcp/tools_pr.go
@@ -186,6 +186,7 @@ func specAddPRComment() Spec {
 			text, _ := req.RequireString("text")
 			filePath := strings.TrimSpace(req.GetString("path", ""))
 			line := req.GetInt("line", 0)
+			lineType := strings.TrimSpace(req.GetString("line_type", ""))
 			parentID := int64(req.GetInt("parent_id", 0))
 			inline := filePath != "" || line > 0
 
@@ -201,6 +202,9 @@ func specAddPRComment() Spec {
 			if inline && parentID > 0 {
 				return mcpgo.NewToolResultError("add_pr_comment: parent_id cannot be combined with path/line; reply to a comment or anchor a new one, not both"), nil
 			}
+			if !inline && lineType != "" {
+				return mcpgo.NewToolResultError("add_pr_comment: line_type only applies to inline comments; provide path and line too"), nil
+			}
 
 			ref := pullrequestservice.RepositoryRef{ProjectKey: project, Slug: repo}
 
@@ -211,7 +215,7 @@ func specAddPRComment() Spec {
 					pullrequestservice.InlineCommentAnchor{
 						Line:     line,
 						Path:     filePath,
-						LineType: req.GetString("line_type", ""),
+						LineType: lineType,
 					},
 				)
 			} else {

--- a/internal/mcp/tools_pr.go
+++ b/internal/mcp/tools_pr.go
@@ -8,7 +8,9 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
+	browseservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/browse"
 	commentservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/comment"
+	diffservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/diff"
 	pullrequestservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/pullrequest"
 	pullrequestactivityservice "github.com/vriesdemichael/bitbucket-server-cli/internal/services/pullrequestactivity"
 )
@@ -37,30 +39,49 @@ func specGetPullRequest() Spec {
 
 func specListPullRequests() Spec {
 	tool := mcpgo.NewTool("list_pull_requests",
-		mcpgo.WithDescription("List pull requests for a repository. Defaults to OPEN state."),
-		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
-		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
+		mcpgo.WithDescription("List pull requests. Without project/repo, lists the current user's PRs across all repositories (dashboard)."),
+		mcpgo.WithString("project", mcpgo.Description("Bitbucket project key (omit for dashboard mode)")),
+		mcpgo.WithString("repo", mcpgo.Description("Repository slug (omit for dashboard mode)")),
 		mcpgo.WithString("state", mcpgo.Description("Filter by state: OPEN (default), MERGED, DECLINED, ALL")),
-		mcpgo.WithString("source_branch", mcpgo.Description("Filter by source branch name")),
-		mcpgo.WithString("target_branch", mcpgo.Description("Filter by target branch name")),
+		mcpgo.WithString("role", mcpgo.Description("Filter by role: REVIEWER, AUTHOR, or PARTICIPANT (works in both repo and dashboard mode)")),
+		mcpgo.WithString("source_branch", mcpgo.Description("Filter by source branch name (repo mode only)")),
+		mcpgo.WithString("target_branch", mcpgo.Description("Filter by target branch name (repo mode only)")),
 		mcpgo.WithNumber("limit", mcpgo.Description("Maximum number of results (default 25)")),
 	)
 	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
 		svc := pullrequestservice.NewService(c.HTTP)
 		return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-			project, _ := req.RequireString("project")
-			repo, _ := req.RequireString("repo")
-			opts := pullrequestservice.ListOptions{
-				State:        req.GetString("state", "OPEN"),
-				SourceBranch: req.GetString("source_branch", ""),
-				TargetBranch: req.GetString("target_branch", ""),
-				Limit:        req.GetInt("limit", 25),
+			project := req.GetString("project", "")
+			repo := req.GetString("repo", "")
+			state := req.GetString("state", "OPEN")
+			limit := req.GetInt("limit", 25)
+
+			var prs []pullrequestservice.PullRequest
+			var err error
+
+			if project != "" && repo != "" {
+				opts := pullrequestservice.ListOptions{
+					State:        state,
+					Role:         req.GetString("role", ""),
+					SourceBranch: req.GetString("source_branch", ""),
+					TargetBranch: req.GetString("target_branch", ""),
+					Limit:        limit,
+				}
+				prs, err = svc.List(ctx, pullrequestservice.RepositoryRef{ProjectKey: project, Slug: repo}, opts)
+			} else if project != "" || repo != "" {
+				return mcpgo.NewToolResultError("list_pull_requests requires both project and repo, or neither for dashboard mode"), nil
+			} else {
+				opts := pullrequestservice.DashboardListOptions{
+					State: state,
+					Role:  req.GetString("role", "REVIEWER"),
+					Limit: limit,
+				}
+				prs, err = svc.ListDashboard(ctx, opts)
 			}
-			prs, err := svc.List(ctx, pullrequestservice.RepositoryRef{ProjectKey: project, Slug: repo}, opts)
 			if err != nil {
 				return mcpgo.NewToolResultErrorFromErr("list_pull_requests failed", err), nil
 			}
-			return resultJSON(prs)
+			return resultJSON(map[string]any{"pull_requests": prs})
 		}
 	}}
 }
@@ -146,24 +167,40 @@ func specListPRComments() Spec {
 
 func specAddPRComment() Spec {
 	tool := mcpgo.NewTool("add_pr_comment",
-		mcpgo.WithDescription("Add a comment to a pull request."),
+		mcpgo.WithDescription("Add a comment to a pull request. Provide path and line to create an inline comment on a specific file line. Provide parent_id to reply to an existing comment."),
 		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
 		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
 		mcpgo.WithString("pr_id", mcpgo.Required(), mcpgo.Description("Pull request ID")),
 		mcpgo.WithString("text", mcpgo.Required(), mcpgo.Description("Comment text (Markdown supported)")),
+		mcpgo.WithString("path", mcpgo.Description("File path for inline comment (e.g. src/main.go)")),
+		mcpgo.WithNumber("line", mcpgo.Description("Line number for inline comment")),
+		mcpgo.WithString("line_type", mcpgo.Description("Diff side for inline comment: ADDED (default), REMOVED, or CONTEXT")),
+		mcpgo.WithNumber("parent_id", mcpgo.Description("Parent comment ID to reply to")),
 	)
 	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
-		svc := commentservice.NewService(c.OpenAPI)
+		svc := pullrequestservice.NewService(c.HTTP)
 		return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 			project, _ := req.RequireString("project")
 			repo, _ := req.RequireString("repo")
 			prID, _ := req.RequireString("pr_id")
 			text, _ := req.RequireString("text")
-			target := commentservice.Target{
-				Repository:    commentservice.RepositoryRef{ProjectKey: project, Slug: repo},
-				PullRequestID: prID,
+			filePath := req.GetString("path", "")
+			line := req.GetInt("line", 0)
+			ref := pullrequestservice.RepositoryRef{ProjectKey: project, Slug: repo}
+			var comment pullrequestservice.Comment
+			var err error
+			if filePath != "" && line > 0 {
+				comment, err = svc.AddInlineComment(ctx, ref, prID, text,
+					pullrequestservice.InlineCommentAnchor{
+						Line:     line,
+						Path:    filePath,
+						LineType: req.GetString("line_type", "ADDED"),
+					},
+				)
+			} else {
+				parentID := int64(req.GetInt("parent_id", 0))
+				comment, err = svc.AddComment(ctx, ref, prID, text, parentID)
 			}
-			comment, err := svc.Create(ctx, target, text)
 			if err != nil {
 				return mcpgo.NewToolResultErrorFromErr("add_pr_comment failed", err), nil
 			}
@@ -205,12 +242,12 @@ func specListPRTasks() Spec {
 
 func specSubmitPRReview() Spec {
 	tool := mcpgo.NewTool("submit_pr_review",
-		mcpgo.WithDescription("Approve or unapprove a pull request."),
+		mcpgo.WithDescription("Set review status on a pull request: approve, unapprove, or request changes (needs_work)."),
 		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
 		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
 		mcpgo.WithString("pr_id", mcpgo.Required(), mcpgo.Description("Pull request ID")),
-		mcpgo.WithString("action", mcpgo.Required(), mcpgo.Description("Action to take: approve or unapprove"),
-			mcpgo.Enum("approve", "unapprove")),
+		mcpgo.WithString("action", mcpgo.Required(), mcpgo.Description("Action to take: approve, unapprove, or needs_work"),
+			mcpgo.Enum("approve", "unapprove", "needs_work")),
 	)
 	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
 		svc := pullrequestservice.NewService(c.HTTP)
@@ -227,6 +264,8 @@ func specSubmitPRReview() Spec {
 				pr, err = svc.Approve(ctx, ref, prID)
 			case "unapprove":
 				pr, err = svc.Unapprove(ctx, ref, prID)
+			case "needs_work":
+				pr, err = svc.NeedsWork(ctx, ref, prID)
 			default:
 				return mcpgo.NewToolResultErrorFromErr("submit_pr_review: unknown action "+strconv.Quote(action), nil), nil
 			}
@@ -338,4 +377,54 @@ func parseCommaList(s string) []string {
 		return nil
 	}
 	return result
+}
+
+func specGetPRDiff() Spec {
+	tool := mcpgo.NewTool("get_pr_diff",
+		mcpgo.WithDescription("Get the diff of a pull request as unified diff text."),
+		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
+		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
+		mcpgo.WithString("pr_id", mcpgo.Required(), mcpgo.Description("Pull request ID")),
+	)
+	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
+		svc := diffservice.NewService(c.OpenAPI)
+		return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			project, _ := req.RequireString("project")
+			repo, _ := req.RequireString("repo")
+			prID, _ := req.RequireString("pr_id")
+			result, err := svc.DiffPR(ctx, diffservice.DiffPRInput{
+				Repository:    diffservice.RepositoryRef{ProjectKey: project, Slug: repo},
+				PullRequestID: prID,
+				Output:        diffservice.OutputKindRaw,
+			})
+			if err != nil {
+				return mcpgo.NewToolResultErrorFromErr("get_pr_diff failed", err), nil
+			}
+			return resultJSON(result)
+		}
+	}}
+}
+
+func specGetFileContent() Spec {
+	tool := mcpgo.NewTool("get_file_content",
+		mcpgo.WithDescription("Get the raw content of a file in a repository."),
+		mcpgo.WithString("project", mcpgo.Required(), mcpgo.Description("Bitbucket project key")),
+		mcpgo.WithString("repo", mcpgo.Required(), mcpgo.Description("Repository slug")),
+		mcpgo.WithString("path", mcpgo.Required(), mcpgo.Description("File path in the repository")),
+		mcpgo.WithString("at", mcpgo.Description("Git ref or branch to read from (e.g. refs/heads/main)")),
+	)
+	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
+		svc := browseservice.NewService(c.OpenAPI, c.HTTP, c.BaseURL)
+		return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			project, _ := req.RequireString("project")
+			repo, _ := req.RequireString("repo")
+			path, _ := req.RequireString("path")
+			at := req.GetString("at", "")
+			content, err := svc.Raw(ctx, browseservice.RepositoryRef{ProjectKey: project, Slug: repo}, path, at)
+			if err != nil {
+				return mcpgo.NewToolResultErrorFromErr("get_file_content failed", err), nil
+			}
+			return mcpgo.NewToolResultText(string(content)), nil
+		}
+	}}
 }

--- a/internal/mcp/tools_pr.go
+++ b/internal/mcp/tools_pr.go
@@ -184,21 +184,37 @@ func specAddPRComment() Spec {
 			repo, _ := req.RequireString("repo")
 			prID, _ := req.RequireString("pr_id")
 			text, _ := req.RequireString("text")
-			filePath := req.GetString("path", "")
+			filePath := strings.TrimSpace(req.GetString("path", ""))
 			line := req.GetInt("line", 0)
+			parentID := int64(req.GetInt("parent_id", 0))
+			inline := filePath != "" || line > 0
+
+			// Reject partial or conflicting anchors rather than silently
+			// downgrading to a general comment, which would leave the comment
+			// attached to the wrong place with no indication anything was off.
+			if inline && filePath == "" {
+				return mcpgo.NewToolResultError("add_pr_comment: line requires path for an inline comment"), nil
+			}
+			if inline && line <= 0 {
+				return mcpgo.NewToolResultError("add_pr_comment: path requires a positive line for an inline comment"), nil
+			}
+			if inline && parentID > 0 {
+				return mcpgo.NewToolResultError("add_pr_comment: parent_id cannot be combined with path/line; reply to a comment or anchor a new one, not both"), nil
+			}
+
 			ref := pullrequestservice.RepositoryRef{ProjectKey: project, Slug: repo}
+
 			var comment pullrequestservice.Comment
 			var err error
-			if filePath != "" && line > 0 {
+			if inline {
 				comment, err = svc.AddInlineComment(ctx, ref, prID, text,
 					pullrequestservice.InlineCommentAnchor{
 						Line:     line,
-						Path:    filePath,
-						LineType: req.GetString("line_type", "ADDED"),
+						Path:     filePath,
+						LineType: req.GetString("line_type", ""),
 					},
 				)
 			} else {
-				parentID := int64(req.GetInt("parent_id", 0))
 				comment, err = svc.AddComment(ctx, ref, prID, text, parentID)
 			}
 			if err != nil {
@@ -414,7 +430,7 @@ func specGetFileContent() Spec {
 		mcpgo.WithString("at", mcpgo.Description("Git ref or branch to read from (e.g. refs/heads/main)")),
 	)
 	return Spec{Tool: tool, Handler: func(c Clients) server.ToolHandlerFunc {
-		svc := browseservice.NewService(c.OpenAPI, c.HTTP, c.BaseURL)
+		svc := browseservice.NewService(c.OpenAPI, c.HTTP)
 		return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 			project, _ := req.RequireString("project")
 			repo, _ := req.RequireString("repo")

--- a/internal/mcp/tools_pr_test.go
+++ b/internal/mcp/tools_pr_test.go
@@ -368,3 +368,20 @@ func resultText(result *mcpgo.CallToolResult) string {
 	}
 	return builder.String()
 }
+
+func TestAddPRCommentRejectsLineTypeWithoutAnchor(t *testing.T) {
+	clients := newRecordingClients(t, `{"id":1}`, func(r *http.Request, body []byte) {
+		t.Errorf("no request should be made, got %s %s", r.Method, r.URL.Path)
+	})
+
+	result := callTool(t, specAddPRComment(), clients, map[string]any{
+		"project": "TEST", "repo": "demo", "pr_id": "30", "text": "hi",
+		"line_type": "ADDED",
+	})
+	if !result.IsError {
+		t.Fatalf("expected an error result, got: %+v", result)
+	}
+	if text := resultText(result); !strings.Contains(text, "line_type only applies") {
+		t.Fatalf("expected a line_type message, got %q", text)
+	}
+}

--- a/internal/mcp/tools_pr_test.go
+++ b/internal/mcp/tools_pr_test.go
@@ -1,8 +1,19 @@
 package mcp
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/config"
 )
 
 func TestParseCommaList(t *testing.T) {
@@ -27,4 +38,333 @@ func TestParseCommaList(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newRecordingClients builds Clients against a server that records the last
+// request it saw and replies with a canned JSON body.
+func newRecordingClients(t *testing.T, response string, record func(r *http.Request, body []byte)) Clients {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if record != nil {
+			record(r, body)
+		}
+		w.Header().Set("Content-Type", "application/json;charset=UTF-8")
+		_, _ = w.Write([]byte(response))
+	}))
+	t.Cleanup(srv.Close)
+
+	clients, err := ClientsFromConfig(config.AppConfig{
+		BitbucketURL:   srv.URL,
+		RequestTimeout: 5 * time.Second,
+		RetryCount:     0,
+		RetryBackoff:   time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("ClientsFromConfig failed: %v", err)
+	}
+	return clients
+}
+
+func callTool(t *testing.T, spec Spec, clients Clients, args map[string]any) *mcpgo.CallToolResult {
+	t.Helper()
+
+	result, err := spec.Handler(clients)(context.Background(), mcpgo.CallToolRequest{
+		Params: mcpgo.CallToolParams{Arguments: args},
+	})
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("handler returned a nil result")
+	}
+	return result
+}
+
+func TestAddPRCommentRejectsPartialAnchors(t *testing.T) {
+	clients := newRecordingClients(t, `{"id":1}`, func(r *http.Request, body []byte) {
+		t.Errorf("no request should be made for an invalid anchor, got %s %s", r.Method, r.URL.Path)
+	})
+
+	base := map[string]any{"project": "TEST", "repo": "demo", "pr_id": "30", "text": "hi"}
+
+	cases := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{
+			name: "line without path",
+			args: map[string]any{"line": 12},
+			want: "line requires path",
+		},
+		{
+			name: "path without line",
+			args: map[string]any{"path": "src/main.go"},
+			want: "requires a positive line",
+		},
+		{
+			name: "path with zero line",
+			args: map[string]any{"path": "src/main.go", "line": 0},
+			want: "requires a positive line",
+		},
+		{
+			name: "inline combined with parent_id",
+			args: map[string]any{"path": "src/main.go", "line": 12, "parent_id": 900},
+			want: "parent_id cannot be combined",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			args := map[string]any{}
+			for key, value := range base {
+				args[key] = value
+			}
+			for key, value := range testCase.args {
+				args[key] = value
+			}
+
+			result := callTool(t, specAddPRComment(), clients, args)
+			if !result.IsError {
+				t.Fatalf("expected an error result, got: %+v", result)
+			}
+			if text := resultText(result); !strings.Contains(text, testCase.want) {
+				t.Fatalf("expected the error to mention %q, got %q", testCase.want, text)
+			}
+		})
+	}
+}
+
+func TestAddPRCommentRoutesInlineAndPlain(t *testing.T) {
+	t.Run("inline anchors the comment", func(t *testing.T) {
+		var payload map[string]any
+		clients := newRecordingClients(t, `{"id":1}`, func(r *http.Request, body []byte) {
+			payload = map[string]any{}
+			_ = json.Unmarshal(body, &payload)
+		})
+
+		result := callTool(t, specAddPRComment(), clients, map[string]any{
+			"project": "TEST", "repo": "demo", "pr_id": "30", "text": "nit",
+			"path": "src/main.go", "line": 12, "line_type": "CONTEXT",
+		})
+		if result.IsError {
+			t.Fatalf("expected success, got: %s", resultText(result))
+		}
+
+		anchor, ok := payload["anchor"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected an anchor in the payload, got %#v", payload)
+		}
+		if anchor["lineType"] != "CONTEXT" {
+			t.Fatalf("expected the requested lineType to be forwarded, got %#v", anchor["lineType"])
+		}
+	})
+
+	t.Run("reply carries the parent", func(t *testing.T) {
+		var payload map[string]any
+		clients := newRecordingClients(t, `{"id":1}`, func(r *http.Request, body []byte) {
+			payload = map[string]any{}
+			_ = json.Unmarshal(body, &payload)
+		})
+
+		result := callTool(t, specAddPRComment(), clients, map[string]any{
+			"project": "TEST", "repo": "demo", "pr_id": "30", "text": "agreed",
+			"parent_id": 900,
+		})
+		if result.IsError {
+			t.Fatalf("expected success, got: %s", resultText(result))
+		}
+
+		parent, ok := payload["parent"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected a parent in the payload, got %#v", payload)
+		}
+		if id, _ := parent["id"].(float64); int(id) != 900 {
+			t.Fatalf("expected parent id 900, got %#v", parent["id"])
+		}
+		if _, hasAnchor := payload["anchor"]; hasAnchor {
+			t.Fatalf("a reply must not be anchored, got %#v", payload)
+		}
+	})
+
+	t.Run("invalid line_type is rejected", func(t *testing.T) {
+		clients := newRecordingClients(t, `{"id":1}`, nil)
+
+		result := callTool(t, specAddPRComment(), clients, map[string]any{
+			"project": "TEST", "repo": "demo", "pr_id": "30", "text": "nit",
+			"path": "src/main.go", "line": 12, "line_type": "SIDEWAYS",
+		})
+		if !result.IsError {
+			t.Fatalf("expected an error result, got: %+v", result)
+		}
+	})
+}
+
+func TestListPullRequestsModeSelection(t *testing.T) {
+	t.Run("repo mode queries the repository endpoint", func(t *testing.T) {
+		var gotPath string
+		var gotQuery url.Values
+		clients := newRecordingClients(t, `{"values":[],"isLastPage":true}`, func(r *http.Request, body []byte) {
+			gotPath = r.URL.Path
+			gotQuery = r.URL.Query()
+		})
+
+		result := callTool(t, specListPullRequests(), clients, map[string]any{
+			"project": "TEST", "repo": "demo", "role": "author",
+		})
+		if result.IsError {
+			t.Fatalf("expected success, got: %s", resultText(result))
+		}
+		if gotPath != "/rest/api/latest/projects/TEST/repos/demo/pull-requests" {
+			t.Fatalf("unexpected path %q", gotPath)
+		}
+		if gotQuery.Get("role") != "AUTHOR" {
+			t.Fatalf("expected role AUTHOR, got %q", gotQuery.Get("role"))
+		}
+	})
+
+	t.Run("dashboard mode queries the dashboard endpoint", func(t *testing.T) {
+		var gotPath string
+		clients := newRecordingClients(t, `{"values":[],"isLastPage":true}`, func(r *http.Request, body []byte) {
+			gotPath = r.URL.Path
+		})
+
+		result := callTool(t, specListPullRequests(), clients, map[string]any{})
+		if result.IsError {
+			t.Fatalf("expected success, got: %s", resultText(result))
+		}
+		if !strings.Contains(gotPath, "dashboard") {
+			t.Fatalf("expected the dashboard endpoint, got %q", gotPath)
+		}
+	})
+
+	t.Run("project without repo is rejected", func(t *testing.T) {
+		clients := newRecordingClients(t, `{}`, func(r *http.Request, body []byte) {
+			t.Errorf("no request should be made, got %s", r.URL.Path)
+		})
+
+		for _, args := range []map[string]any{
+			{"project": "TEST"},
+			{"repo": "demo"},
+		} {
+			result := callTool(t, specListPullRequests(), clients, args)
+			if !result.IsError {
+				t.Fatalf("expected an error result for %#v, got: %+v", args, result)
+			}
+			if text := resultText(result); !strings.Contains(text, "both project and repo") {
+				t.Fatalf("expected a both-or-neither message, got %q", text)
+			}
+		}
+	})
+}
+
+func TestSubmitPRReviewNeedsWorkAction(t *testing.T) {
+	var gotMethod string
+	var gotPath string
+	var payload map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json;charset=UTF-8")
+
+		// Every authenticated response carries the current user, which is how
+		// needs_work resolves the participant to update.
+		w.Header().Set("X-AUSERNAME", "alice")
+		if r.URL.Path == "/rest/api/latest/users" {
+			_, _ = w.Write([]byte(`{"values":[]}`))
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		payload = map[string]any{}
+		_ = json.Unmarshal(body, &payload)
+
+		_, _ = w.Write([]byte(`{"id":30,"state":"OPEN","open":true,"participants":[{"role":"REVIEWER","status":"NEEDS_WORK","user":{"name":"alice"}}]}`))
+	}))
+	defer srv.Close()
+
+	clients, err := ClientsFromConfig(config.AppConfig{
+		BitbucketURL:   srv.URL,
+		RequestTimeout: 5 * time.Second,
+		RetryCount:     0,
+		RetryBackoff:   time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("ClientsFromConfig failed: %v", err)
+	}
+
+	result := callTool(t, specSubmitPRReview(), clients, map[string]any{
+		"project": "TEST", "repo": "demo", "pr_id": "30", "action": "needs_work",
+	})
+	if result.IsError {
+		t.Fatalf("expected success, got: %s", resultText(result))
+	}
+
+	if gotMethod != http.MethodPut {
+		t.Fatalf("expected PUT for needs_work, got %s", gotMethod)
+	}
+	if gotPath != "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants/alice" {
+		t.Fatalf("unexpected participant path %q", gotPath)
+	}
+	if payload["status"] != "NEEDS_WORK" {
+		t.Fatalf("expected a NEEDS_WORK payload, got %#v", payload)
+	}
+}
+
+func TestSubmitPRReviewRejectsUnknownAction(t *testing.T) {
+	clients := newRecordingClients(t, `{}`, nil)
+
+	result := callTool(t, specSubmitPRReview(), clients, map[string]any{
+		"project": "TEST", "repo": "demo", "pr_id": "30", "action": "merge",
+	})
+	if !result.IsError {
+		t.Fatalf("expected an error result, got: %+v", result)
+	}
+}
+
+func TestGetFileContentReturnsRawText(t *testing.T) {
+	var gotPath string
+	clients := newRecordingClients(t, "package main\n", func(r *http.Request, body []byte) {
+		gotPath = r.URL.Path
+	})
+
+	result := callTool(t, specGetFileContent(), clients, map[string]any{
+		"project": "TEST", "repo": "demo", "path": "src/main.go", "at": "refs/heads/main",
+	})
+	if result.IsError {
+		t.Fatalf("expected success, got: %s", resultText(result))
+	}
+	if gotPath != "/rest/api/latest/projects/TEST/repos/demo/raw/src/main.go" {
+		t.Fatalf("unexpected path %q", gotPath)
+	}
+	if text := resultText(result); !strings.Contains(text, "package main") {
+		t.Fatalf("expected the file body, got %q", text)
+	}
+}
+
+func TestGetFileContentRejectsTraversal(t *testing.T) {
+	clients := newRecordingClients(t, `{}`, func(r *http.Request, body []byte) {
+		t.Errorf("no request should be made for a traversal path, got %s", r.URL.Path)
+	})
+
+	result := callTool(t, specGetFileContent(), clients, map[string]any{
+		"project": "TEST", "repo": "demo", "path": "../../../etc/passwd",
+	})
+	if !result.IsError {
+		t.Fatalf("expected an error result, got: %+v", result)
+	}
+}
+
+// resultText flattens a tool result's content into a single string.
+func resultText(result *mcpgo.CallToolResult) string {
+	var builder strings.Builder
+	for _, content := range result.Content {
+		if text, ok := content.(mcpgo.TextContent); ok {
+			builder.WriteString(text.Text)
+		}
+	}
+	return builder.String()
 }

--- a/internal/services/browse/service.go
+++ b/internal/services/browse/service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"mime/multipart"
+	"net/url"
 	"strings"
 
 	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
@@ -37,13 +38,12 @@ type EditInput struct {
 }
 
 type Service struct {
-	client  *openapigenerated.ClientWithResponses
-	http    *httpclient.Client
-	baseURL string
+	client *openapigenerated.ClientWithResponses
+	http   *httpclient.Client
 }
 
-func NewService(client *openapigenerated.ClientWithResponses, http *httpclient.Client, baseURL string) *Service {
-	return &Service{client: client, http: http, baseURL: baseURL}
+func NewService(client *openapigenerated.ClientWithResponses, http *httpclient.Client) *Service {
+	return &Service{client: client, http: http}
 }
 
 func (service *Service) Tree(ctx context.Context, repo RepositoryRef, path string, options TreeOptions) ([]string, error) {
@@ -134,21 +134,17 @@ func (service *Service) Raw(ctx context.Context, repo RepositoryRef, path string
 		return nil, err
 	}
 
-	trimmedPath := strings.TrimSpace(path)
-	if trimmedPath == "" {
-		return nil, apperrors.New(apperrors.KindValidation, "path is required", nil)
+	encodedPath, err := encodeFilePath(path)
+	if err != nil {
+		return nil, err
 	}
 
-	// The OpenAPI generated client URL-encodes "/" in the path parameter to "%2F",
-	// but Bitbucket Server's /raw/{path} endpoint expects "/" as a real URL path
-	// separator. Use httpclient.GetRaw directly to construct the correct URL.
-	apiPath := fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/raw/%s", repo.ProjectKey, repo.Slug, trimmedPath)
 	query := map[string]string{}
 	if strings.TrimSpace(at) != "" {
 		query["at"] = strings.TrimSpace(at)
 	}
 
-	return service.http.GetRaw(ctx, apiPath, query)
+	return service.http.GetRaw(ctx, repositoryAPIPath(repo, "raw", encodedPath), query)
 }
 
 func (service *Service) File(ctx context.Context, repo RepositoryRef, path string, options FileOptions) ([]byte, error) {
@@ -156,48 +152,20 @@ func (service *Service) File(ctx context.Context, repo RepositoryRef, path strin
 		return nil, err
 	}
 
-	trimmedPath := strings.TrimSpace(path)
-	if trimmedPath == "" {
-		return nil, apperrors.New(apperrors.KindValidation, "path is required", nil)
-	}
-
-	// Same issue as Raw: generated client URL-encodes "/" in path.
-	// Use httpclient.GetRaw for paths containing "/".
-	if strings.Contains(trimmedPath, "/") {
-		apiPath := fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/browse/%s", repo.ProjectKey, repo.Slug, trimmedPath)
-		query := map[string]string{}
-		if strings.TrimSpace(options.At) != "" {
-			query["at"] = strings.TrimSpace(options.At)
-		}
-		if options.Blame {
-			query["blame"] = "true"
-		}
-		return service.http.GetRaw(ctx, apiPath, query)
-	}
-
-	var atParam *string
-	if strings.TrimSpace(options.At) != "" {
-		a := strings.TrimSpace(options.At)
-		atParam = &a
-	}
-
-	var blameParam *string
-	if options.Blame {
-		b := "true"
-		blameParam = &b
-	}
-
-	params := &openapigenerated.GetContent1Params{At: atParam, Blame: blameParam}
-	resp, err := service.client.GetContent1WithResponse(ctx, repo.ProjectKey, repo.Slug, trimmedPath, params)
+	encodedPath, err := encodeFilePath(path)
 	if err != nil {
-		return nil, apperrors.New(apperrors.KindTransient, "failed to get file content", err)
-	}
-
-	if err := openapi.MapStatusError(resp.StatusCode(), resp.Body); err != nil {
 		return nil, err
 	}
 
-	return resp.Body, nil
+	query := map[string]string{}
+	if strings.TrimSpace(options.At) != "" {
+		query["at"] = strings.TrimSpace(options.At)
+	}
+	if options.Blame {
+		query["blame"] = "true"
+	}
+
+	return service.http.GetRaw(ctx, repositoryAPIPath(repo, "browse", encodedPath), query)
 }
 
 func (service *Service) Edit(ctx context.Context, repo RepositoryRef, path string, input EditInput) (*openapigenerated.RestCommit, error) {
@@ -264,4 +232,47 @@ func validateRepositoryRef(repo RepositoryRef) error {
 		return apperrors.New(apperrors.KindValidation, "repository must be specified as project/repo", nil)
 	}
 	return nil
+}
+
+// repositoryAPIPath builds a REST path for a repository endpoint that takes a
+// file path as a trailing wildcard, such as /raw/{path} or /browse/{path}.
+// encodedPath must already be escaped by encodeFilePath.
+func repositoryAPIPath(repo RepositoryRef, endpoint string, encodedPath string) string {
+	return fmt.Sprintf(
+		"/rest/api/latest/projects/%s/repos/%s/%s/%s",
+		url.PathEscape(strings.TrimSpace(repo.ProjectKey)),
+		url.PathEscape(strings.TrimSpace(repo.Slug)),
+		endpoint,
+		encodedPath,
+	)
+}
+
+// encodeFilePath escapes each segment of a repository file path and rejoins them
+// with real "/" separators.
+//
+// The generated OpenAPI client escapes the whole path as a single parameter,
+// turning "/" into "%2F", which the /raw/{path} and /browse/{path} endpoints do
+// not accept. Escaping per segment keeps the separators intact while ensuring a
+// path cannot introduce query parameters, fragments, or traversal that would
+// redirect the request to a different endpoint.
+func encodeFilePath(path string) (string, error) {
+	segments := strings.Split(strings.TrimSpace(path), "/")
+	encoded := make([]string, 0, len(segments))
+
+	for _, segment := range segments {
+		trimmed := strings.TrimSpace(segment)
+		if trimmed == "" || trimmed == "." {
+			continue
+		}
+		if trimmed == ".." {
+			return "", apperrors.New(apperrors.KindValidation, `path must not contain ".." segments`, nil)
+		}
+		encoded = append(encoded, url.PathEscape(trimmed))
+	}
+
+	if len(encoded) == 0 {
+		return "", apperrors.New(apperrors.KindValidation, "path is required", nil)
+	}
+
+	return strings.Join(encoded, "/"), nil
 }

--- a/internal/services/browse/service.go
+++ b/internal/services/browse/service.go
@@ -3,9 +3,11 @@ package browse
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"mime/multipart"
 	"net/url"
+	"strconv"
 	"strings"
 
 	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
@@ -51,82 +53,58 @@ func (service *Service) Tree(ctx context.Context, repo RepositoryRef, path strin
 		return nil, err
 	}
 
-	trimmedPath := strings.TrimSpace(path)
+	// The /files endpoint takes the directory as a trailing wildcard, so it
+	// needs the same per-segment escaping as /raw and /browse.
+	encodedPath, err := encodeOptionalFilePath(path)
+	if err != nil {
+		return nil, err
+	}
 
 	if options.Limit <= 0 {
 		options.Limit = 1000
 	}
 
-	start := float32(0)
-	pageLimit := float32(options.Limit)
-	var at *string
-	if strings.TrimSpace(options.At) != "" {
-		a := strings.TrimSpace(options.At)
-		at = &a
-	}
-
+	apiPath := repositoryAPIPath(repo, "files", encodedPath)
 	results := make([]string, 0)
+	start := 0
 
 	for {
-		var responseStatus int
-		var responseBody []byte
-		var responseValues *[]openapigenerated.FileListResource
-		var responseIsLastPage *bool
-		var responseNextPageStart *int32
-
-		if trimmedPath == "" {
-			params := &openapigenerated.StreamFilesParams{Start: &start, Limit: &pageLimit, At: at}
-			resp, err := service.client.StreamFilesWithResponse(ctx, repo.ProjectKey, repo.Slug, params)
-			if err != nil {
-				return nil, apperrors.New(apperrors.KindTransient, "failed to stream repository files", err)
-			}
-			responseStatus = resp.StatusCode()
-			responseBody = resp.Body
-			if resp.ApplicationjsonCharsetUTF8200 != nil {
-				responseValues = resp.ApplicationjsonCharsetUTF8200.Values
-				responseIsLastPage = resp.ApplicationjsonCharsetUTF8200.IsLastPage
-				responseNextPageStart = resp.ApplicationjsonCharsetUTF8200.NextPageStart
-			}
-		} else {
-			params := &openapigenerated.StreamFiles1Params{Start: &start, Limit: &pageLimit, At: at}
-			resp, err := service.client.StreamFiles1WithResponse(ctx, repo.ProjectKey, repo.Slug, trimmedPath, params)
-			if err != nil {
-				return nil, apperrors.New(apperrors.KindTransient, "failed to stream repository files", err)
-			}
-			responseStatus = resp.StatusCode()
-			responseBody = resp.Body
-			if resp.ApplicationjsonCharsetUTF8200 != nil {
-				responseValues = resp.ApplicationjsonCharsetUTF8200.Values
-				responseIsLastPage = resp.ApplicationjsonCharsetUTF8200.IsLastPage
-				responseNextPageStart = resp.ApplicationjsonCharsetUTF8200.NextPageStart
-			}
+		query := map[string]string{
+			"start": strconv.Itoa(start),
+			"limit": strconv.Itoa(options.Limit),
+		}
+		if strings.TrimSpace(options.At) != "" {
+			query["at"] = strings.TrimSpace(options.At)
 		}
 
-		if err := openapi.MapStatusError(responseStatus, responseBody); err != nil {
+		var response fileListResponse
+		if err := service.http.GetJSON(ctx, apiPath, query, &response); err != nil {
 			return nil, err
 		}
 
-		if responseValues == nil {
-			break
-		}
-
-		for _, val := range *responseValues {
-			if strVal, ok := val.(string); ok {
-				results = append(results, strVal)
+		for _, value := range response.Values {
+			if name, ok := value.(string); ok {
+				results = append(results, name)
 			}
 		}
 
-		if responseIsLastPage != nil && *responseIsLastPage {
+		if response.IsLastPage || response.NextPageStart == nil {
 			break
 		}
-		if responseNextPageStart == nil {
+		if *response.NextPageStart == start {
 			break
 		}
 
-		start = float32(*responseNextPageStart)
+		start = *response.NextPageStart
 	}
 
 	return results, nil
+}
+
+type fileListResponse struct {
+	Values        []any `json:"values"`
+	IsLastPage    bool  `json:"isLastPage"`
+	NextPageStart *int  `json:"nextPageStart"`
 }
 
 func (service *Service) Raw(ctx context.Context, repo RepositoryRef, path string, at string) ([]byte, error) {
@@ -165,7 +143,14 @@ func (service *Service) File(ctx context.Context, repo RepositoryRef, path strin
 		query["blame"] = "true"
 	}
 
-	return service.http.GetRaw(ctx, repositoryAPIPath(repo, "browse", encodedPath), query)
+	// Unlike /raw, the /browse endpoint answers with JSON, so it is requested
+	// as JSON and handed back undecoded for the caller to render.
+	var content json.RawMessage
+	if err := service.http.GetJSON(ctx, repositoryAPIPath(repo, "browse", encodedPath), query, &content); err != nil {
+		return nil, err
+	}
+
+	return content, nil
 }
 
 func (service *Service) Edit(ctx context.Context, repo RepositoryRef, path string, input EditInput) (*openapigenerated.RestCommit, error) {
@@ -236,15 +221,28 @@ func validateRepositoryRef(repo RepositoryRef) error {
 
 // repositoryAPIPath builds a REST path for a repository endpoint that takes a
 // file path as a trailing wildcard, such as /raw/{path} or /browse/{path}.
-// encodedPath must already be escaped by encodeFilePath.
+// encodedPath must already be escaped by encodeFilePath, and may be empty for
+// endpoints where the path is optional.
 func repositoryAPIPath(repo RepositoryRef, endpoint string, encodedPath string) string {
-	return fmt.Sprintf(
-		"/rest/api/latest/projects/%s/repos/%s/%s/%s",
+	base := fmt.Sprintf(
+		"/rest/api/latest/projects/%s/repos/%s/%s",
 		url.PathEscape(strings.TrimSpace(repo.ProjectKey)),
 		url.PathEscape(strings.TrimSpace(repo.Slug)),
 		endpoint,
-		encodedPath,
 	)
+	if encodedPath == "" {
+		return base
+	}
+	return base + "/" + encodedPath
+}
+
+// encodeOptionalFilePath behaves like encodeFilePath but allows an empty path,
+// for endpoints that treat it as "the repository root".
+func encodeOptionalFilePath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", nil
+	}
+	return encodeFilePath(path)
 }
 
 // encodeFilePath escapes each segment of a repository file path and rejoins them

--- a/internal/services/browse/service.go
+++ b/internal/services/browse/service.go
@@ -64,7 +64,11 @@ func (service *Service) Tree(ctx context.Context, repo RepositoryRef, path strin
 		options.Limit = 1000
 	}
 
-	apiPath := repositoryAPIPath(repo, "files", encodedPath)
+	apiPath := repositoryRootPath(repo, "files")
+	if encodedPath != "" {
+		apiPath = repositoryAPIPath(repo, "files", encodedPath)
+	}
+
 	results := make([]string, 0)
 	start := 0
 
@@ -221,19 +225,30 @@ func validateRepositoryRef(repo RepositoryRef) error {
 
 // repositoryAPIPath builds a REST path for a repository endpoint that takes a
 // file path as a trailing wildcard, such as /raw/{path} or /browse/{path}.
-// encodedPath must already be escaped by encodeFilePath, and may be empty for
-// endpoints where the path is optional.
+// encodedPath must already be escaped by encodeFilePath.
+//
+// Kept as a single fmt.Sprintf return so tools/quality-report can statically
+// resolve the endpoints reached through the raw httpclient; see
+// repositoryRootPath for the variant without a trailing path.
 func repositoryAPIPath(repo RepositoryRef, endpoint string, encodedPath string) string {
-	base := fmt.Sprintf(
+	return fmt.Sprintf(
+		"/rest/api/latest/projects/%s/repos/%s/%s/%s",
+		url.PathEscape(strings.TrimSpace(repo.ProjectKey)),
+		url.PathEscape(strings.TrimSpace(repo.Slug)),
+		endpoint,
+		encodedPath,
+	)
+}
+
+// repositoryRootPath builds the same REST path without a trailing file path,
+// for endpoints where it is optional (listing the repository root).
+func repositoryRootPath(repo RepositoryRef, endpoint string) string {
+	return fmt.Sprintf(
 		"/rest/api/latest/projects/%s/repos/%s/%s",
 		url.PathEscape(strings.TrimSpace(repo.ProjectKey)),
 		url.PathEscape(strings.TrimSpace(repo.Slug)),
 		endpoint,
 	)
-	if encodedPath == "" {
-		return base
-	}
-	return base + "/" + encodedPath
 }
 
 // encodeOptionalFilePath behaves like encodeFilePath but allows an empty path,

--- a/internal/services/browse/service.go
+++ b/internal/services/browse/service.go
@@ -3,12 +3,14 @@ package browse
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"mime/multipart"
 	"strings"
 
 	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
 	"github.com/vriesdemichael/bitbucket-server-cli/internal/openapi"
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
 )
 
 type RepositoryRef struct {
@@ -35,11 +37,13 @@ type EditInput struct {
 }
 
 type Service struct {
-	client *openapigenerated.ClientWithResponses
+	client  *openapigenerated.ClientWithResponses
+	http    *httpclient.Client
+	baseURL string
 }
 
-func NewService(client *openapigenerated.ClientWithResponses) *Service {
-	return &Service{client: client}
+func NewService(client *openapigenerated.ClientWithResponses, http *httpclient.Client, baseURL string) *Service {
+	return &Service{client: client, http: http, baseURL: baseURL}
 }
 
 func (service *Service) Tree(ctx context.Context, repo RepositoryRef, path string, options TreeOptions) ([]string, error) {
@@ -135,23 +139,16 @@ func (service *Service) Raw(ctx context.Context, repo RepositoryRef, path string
 		return nil, apperrors.New(apperrors.KindValidation, "path is required", nil)
 	}
 
-	var atParam *string
+	// The OpenAPI generated client URL-encodes "/" in the path parameter to "%2F",
+	// but Bitbucket Server's /raw/{path} endpoint expects "/" as a real URL path
+	// separator. Use httpclient.GetRaw directly to construct the correct URL.
+	apiPath := fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/raw/%s", repo.ProjectKey, repo.Slug, trimmedPath)
+	query := map[string]string{}
 	if strings.TrimSpace(at) != "" {
-		a := strings.TrimSpace(at)
-		atParam = &a
+		query["at"] = strings.TrimSpace(at)
 	}
 
-	params := &openapigenerated.StreamRawParams{At: atParam}
-	resp, err := service.client.StreamRawWithResponse(ctx, repo.ProjectKey, repo.Slug, trimmedPath, params)
-	if err != nil {
-		return nil, apperrors.New(apperrors.KindTransient, "failed to get raw content", err)
-	}
-
-	if err := openapi.MapStatusError(resp.StatusCode(), resp.Body); err != nil {
-		return nil, err
-	}
-
-	return resp.Body, nil
+	return service.http.GetRaw(ctx, apiPath, query)
 }
 
 func (service *Service) File(ctx context.Context, repo RepositoryRef, path string, options FileOptions) ([]byte, error) {
@@ -162,6 +159,20 @@ func (service *Service) File(ctx context.Context, repo RepositoryRef, path strin
 	trimmedPath := strings.TrimSpace(path)
 	if trimmedPath == "" {
 		return nil, apperrors.New(apperrors.KindValidation, "path is required", nil)
+	}
+
+	// Same issue as Raw: generated client URL-encodes "/" in path.
+	// Use httpclient.GetRaw for paths containing "/".
+	if strings.Contains(trimmedPath, "/") {
+		apiPath := fmt.Sprintf("/rest/api/latest/projects/%s/repos/%s/browse/%s", repo.ProjectKey, repo.Slug, trimmedPath)
+		query := map[string]string{}
+		if strings.TrimSpace(options.At) != "" {
+			query["at"] = strings.TrimSpace(options.At)
+		}
+		if options.Blame {
+			query["blame"] = "true"
+		}
+		return service.http.GetRaw(ctx, apiPath, query)
 	}
 
 	var atParam *string

--- a/internal/services/browse/service_test.go
+++ b/internal/services/browse/service_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/config"
 	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
 	"github.com/vriesdemichael/bitbucket-server-cli/internal/openapi"
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
-	"github.com/vriesdemichael/bitbucket-server-cli/internal/config"
 	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
 )
 
@@ -25,15 +26,15 @@ func newBrowseTestService(t *testing.T, handler http.HandlerFunc) *Service {
 		t.Fatalf("create client: %v", err)
 	}
 
-	// Build a minimal httpclient.Client for tests using exported constructor.
-	// The config doesn't need real credentials for httptest.
-	cfg := config.AppConfig{
-		BitbucketURL:    server.URL,
-		RequestTimeout:  10 * time.Second,
-		RetryCount:      0,
-	}
-	httpClient := httpclient.NewFromConfig(cfg)
-	return NewService(client, httpClient, strings.TrimRight(server.URL, "/"))
+	// The raw and browse endpoints go through httpclient rather than the
+	// generated client; httptest needs no real credentials.
+	httpClient := httpclient.NewFromConfig(config.AppConfig{
+		BitbucketURL:   server.URL,
+		RequestTimeout: 10 * time.Second,
+		RetryCount:     0,
+	})
+
+	return NewService(client, httpClient)
 }
 
 func TestBrowseServiceCoreCommands(t *testing.T) {
@@ -297,3 +298,140 @@ func TestBrowseServiceEdit(t *testing.T) {
 	})
 }
 
+// TestBrowseServiceNestedPathsKeepSeparators guards the bug this endpoint had
+// before: the generated client escaped "/" to "%2F", which Bitbucket rejects.
+// Separators must survive as real path separators.
+func TestBrowseServiceNestedPathsKeepSeparators(t *testing.T) {
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+
+	var gotRawPath string
+	var gotEscapedPath string
+	var gotQuery url.Values
+	service := newBrowseTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotRawPath = r.URL.EscapedPath()
+		gotEscapedPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	if _, err := service.Raw(context.Background(), repo, "src/main/java/App.java", "refs/heads/main"); err != nil {
+		t.Fatalf("expected raw success, got %v", err)
+	}
+
+	wantPath := "/rest/api/latest/projects/TEST/repos/demo/raw/src/main/java/App.java"
+	if gotEscapedPath != wantPath {
+		t.Fatalf("expected path %q, got %q", wantPath, gotEscapedPath)
+	}
+	if strings.Contains(gotRawPath, "%2F") {
+		t.Fatalf("path separators must not be percent-encoded, got %q", gotRawPath)
+	}
+	if gotQuery.Get("at") != "refs/heads/main" {
+		t.Fatalf("expected at=refs/heads/main, got %q", gotQuery.Get("at"))
+	}
+
+	if _, err := service.File(context.Background(), repo, "docs/readme.md", FileOptions{Blame: true}); err != nil {
+		t.Fatalf("expected file success, got %v", err)
+	}
+	if gotEscapedPath != "/rest/api/latest/projects/TEST/repos/demo/browse/docs/readme.md" {
+		t.Fatalf("unexpected browse path %q", gotEscapedPath)
+	}
+	if gotQuery.Get("blame") != "true" {
+		t.Fatalf("expected blame=true, got %q", gotQuery.Get("blame"))
+	}
+}
+
+// TestBrowseServiceEscapesPathSegments checks that characters which would
+// otherwise reshape the request URL are escaped inside each segment.
+func TestBrowseServiceEscapesPathSegments(t *testing.T) {
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+
+	var gotPath string
+	var gotQuery url.Values
+	service := newBrowseTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	// A "?" in a filename must stay part of the path, not start a query, and
+	// must not let a caller smuggle in their own parameters.
+	if _, err := service.Raw(context.Background(), repo, "weird/na?me=x&at=evil.txt", ""); err != nil {
+		t.Fatalf("expected raw success, got %v", err)
+	}
+
+	wantPath := "/rest/api/latest/projects/TEST/repos/demo/raw/weird/na?me=x&at=evil.txt"
+	if gotPath != wantPath {
+		t.Fatalf("expected literal path %q, got %q", wantPath, gotPath)
+	}
+	if gotQuery.Get("at") != "" || gotQuery.Get("me") != "" {
+		t.Fatalf("path characters leaked into the query: %v", gotQuery)
+	}
+}
+
+func TestBrowseServiceRejectsTraversal(t *testing.T) {
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+
+	service := newBrowseTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("server must not be reached for a traversal path, got %s", r.URL.Path)
+	})
+
+	for _, path := range []string{"../../../etc/passwd", "docs/../../secret", ".."} {
+		if _, err := service.Raw(context.Background(), repo, path, ""); err == nil {
+			t.Fatalf("expected traversal rejection for Raw(%q)", path)
+		} else if apperrors.ExitCode(err) != 2 {
+			t.Fatalf("expected validation exit code 2 for %q, got %d", path, apperrors.ExitCode(err))
+		}
+
+		if _, err := service.File(context.Background(), repo, path, FileOptions{}); err == nil {
+			t.Fatalf("expected traversal rejection for File(%q)", path)
+		}
+	}
+}
+
+func TestEncodeFilePath(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "simple", input: "file.txt", want: "file.txt"},
+		{name: "nested", input: "a/b/c.txt", want: "a/b/c.txt"},
+		{name: "leading slash dropped", input: "/a/b.txt", want: "a/b.txt"},
+		{name: "redundant slashes collapsed", input: "a//b.txt", want: "a/b.txt"},
+		{name: "current dir segments dropped", input: "./a/./b.txt", want: "a/b.txt"},
+		{name: "spaces escaped", input: "my dir/my file.txt", want: "my%20dir/my%20file.txt"},
+		{name: "question mark escaped", input: "a?b.txt", want: "a%3Fb.txt"},
+		{name: "hash escaped", input: "a#b.txt", want: "a%23b.txt"},
+		{name: "percent escaped", input: "a%2Fb.txt", want: "a%252Fb.txt"},
+		{name: "empty", input: "", wantErr: true},
+		{name: "only separators", input: "///", wantErr: true},
+		{name: "traversal", input: "a/../b", wantErr: true},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := encodeFilePath(testCase.input)
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", testCase.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", testCase.input, err)
+			}
+			if got != testCase.want {
+				t.Fatalf("encodeFilePath(%q) = %q, want %q", testCase.input, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestRepositoryAPIPathEscapesRepositoryRef(t *testing.T) {
+	got := repositoryAPIPath(RepositoryRef{ProjectKey: "a b", Slug: "c/d"}, "raw", "file.txt")
+	want := "/rest/api/latest/projects/a%20b/repos/c%2Fd/raw/file.txt"
+	if got != want {
+		t.Fatalf("repositoryAPIPath = %q, want %q", got, want)
+	}
+}

--- a/internal/services/browse/service_test.go
+++ b/internal/services/browse/service_test.go
@@ -2,14 +2,17 @@ package browse
 
 import (
 	"context"
-	"github.com/vriesdemichael/bitbucket-server-cli/internal/openapi"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	apperrors "github.com/vriesdemichael/bitbucket-server-cli/internal/domain/errors"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/openapi"
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/config"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/transport/httpclient"
 )
 
 func newBrowseTestService(t *testing.T, handler http.HandlerFunc) *Service {
@@ -22,7 +25,15 @@ func newBrowseTestService(t *testing.T, handler http.HandlerFunc) *Service {
 		t.Fatalf("create client: %v", err)
 	}
 
-	return NewService(client)
+	// Build a minimal httpclient.Client for tests using exported constructor.
+	// The config doesn't need real credentials for httptest.
+	cfg := config.AppConfig{
+		BitbucketURL:    server.URL,
+		RequestTimeout:  10 * time.Second,
+		RetryCount:      0,
+	}
+	httpClient := httpclient.NewFromConfig(cfg)
+	return NewService(client, httpClient, strings.TrimRight(server.URL, "/"))
 }
 
 func TestBrowseServiceCoreCommands(t *testing.T) {

--- a/internal/services/browse/service_test.go
+++ b/internal/services/browse/service_test.go
@@ -311,7 +311,14 @@ func TestBrowseServiceNestedPathsKeepSeparators(t *testing.T) {
 		gotRawPath = r.URL.EscapedPath()
 		gotEscapedPath = r.URL.Path
 		gotQuery = r.URL.Query()
-		_, _ = w.Write([]byte("ok"))
+
+		// /raw streams bytes, /browse and /files answer with JSON.
+		if strings.Contains(r.URL.Path, "/raw/") {
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"lines":[{"text":"ok"}]}`))
 	})
 
 	if _, err := service.Raw(context.Background(), repo, "src/main/java/App.java", "refs/heads/main"); err != nil {
@@ -433,5 +440,69 @@ func TestRepositoryAPIPathEscapesRepositoryRef(t *testing.T) {
 	want := "/rest/api/latest/projects/a%20b/repos/c%2Fd/raw/file.txt"
 	if got != want {
 		t.Fatalf("repositoryAPIPath = %q, want %q", got, want)
+	}
+}
+
+// TestBrowseServiceTreeNestedPathKeepsSeparators covers the same encoding bug as
+// the raw and browse endpoints: /files takes the directory as a trailing
+// wildcard, so "/" must survive rather than becoming "%2F".
+func TestBrowseServiceTreeNestedPathKeepsSeparators(t *testing.T) {
+	var gotEscapedPath string
+	var gotQuery url.Values
+	service := newBrowseTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEscapedPath = r.URL.EscapedPath()
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"isLastPage":true,"values":["App.java"]}`))
+	})
+
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+
+	files, err := service.Tree(context.Background(), repo, "src/main/java", TreeOptions{Limit: 10, At: "refs/heads/main"})
+	if err != nil {
+		t.Fatalf("expected tree success, got %v", err)
+	}
+	if len(files) != 1 || files[0] != "App.java" {
+		t.Fatalf("unexpected tree result %#v", files)
+	}
+
+	wantPath := "/rest/api/latest/projects/TEST/repos/demo/files/src/main/java"
+	if gotEscapedPath != wantPath {
+		t.Fatalf("expected path %q, got %q", wantPath, gotEscapedPath)
+	}
+	if strings.Contains(gotEscapedPath, "%2F") {
+		t.Fatalf("path separators must not be percent-encoded, got %q", gotEscapedPath)
+	}
+	if gotQuery.Get("at") != "refs/heads/main" || gotQuery.Get("limit") != "10" {
+		t.Fatalf("unexpected query %v", gotQuery)
+	}
+}
+
+func TestBrowseServiceTreeRejectsTraversal(t *testing.T) {
+	service := newBrowseTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("server must not be reached for a traversal path, got %s", r.URL.Path)
+	})
+
+	_, err := service.Tree(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, "../secrets", TreeOptions{})
+	if err == nil || apperrors.ExitCode(err) != 2 {
+		t.Fatalf("expected a validation error, got %v", err)
+	}
+}
+
+func TestBrowseServiceTreeStopsOnRepeatedNextPageStart(t *testing.T) {
+	calls := 0
+	service := newBrowseTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		// A server that keeps pointing at the same offset must not loop forever.
+		_, _ = w.Write([]byte(`{"isLastPage":false,"nextPageStart":0,"values":["a.txt"]}`))
+	})
+
+	files, err := service.Tree(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, "", TreeOptions{})
+	if err != nil {
+		t.Fatalf("expected tree success, got %v", err)
+	}
+	if calls != 1 || len(files) != 1 {
+		t.Fatalf("expected a single page, got calls=%d files=%#v", calls, files)
 	}
 }

--- a/internal/services/pullrequest/service.go
+++ b/internal/services/pullrequest/service.go
@@ -25,6 +25,7 @@ type ListOptions struct {
 	Start        int    `json:"start"`
 	SourceBranch string `json:"source_branch,omitempty"`
 	TargetBranch string `json:"target_branch,omitempty"`
+	Role         string `json:"role,omitempty"`
 }
 
 type PullRequest struct {
@@ -226,6 +227,9 @@ func (service *Service) List(ctx context.Context, repository RepositoryRef, opti
 		} else {
 			query["state"] = "ALL"
 		}
+		if options.Role != "" {
+			query["role"] = strings.ToUpper(options.Role)
+		}
 
 		var response pagedPullRequestResponse
 		if err := service.client.GetJSON(ctx, path, query, &response); err != nil {
@@ -389,6 +393,119 @@ func (service *Service) Unapprove(ctx context.Context, repository RepositoryRef,
 	}
 
 	return mapPullRequest(response), nil
+}
+
+// NeedsWork sets the current user's review status to NEEDS_WORK on a pull request.
+// Uses PUT .../participants/{userSlug} with {"status": "NEEDS_WORK"}.
+// The userSlug is resolved by posting a temporary comment and reading the author from the response.
+func (service *Service) NeedsWork(ctx context.Context, repository RepositoryRef, pullRequestID string) (PullRequest, error) {
+	if err := validateRepositoryRef(repository); err != nil {
+		return PullRequest{}, err
+	}
+
+	resolvedID, err := normalizePullRequestID(pullRequestID)
+	if err != nil {
+		return PullRequest{}, err
+	}
+
+	userSlug, err := service.client.CurrentUserSlug(ctx)
+	if err != nil {
+		return PullRequest{}, err
+	}
+
+	path := fmt.Sprintf("%s/%s/participants/%s", pullRequestPath(repository), resolvedID, url.PathEscape(userSlug))
+	payload := map[string]any{"status": "NEEDS_WORK"}
+
+	var response pullRequestValue
+	if err := service.client.PutJSON(ctx, path, nil, payload, &response); err != nil {
+		return PullRequest{}, err
+	}
+
+	return mapPullRequest(response), nil
+}
+
+// InlineCommentAnchor specifies the file location for an inline PR comment.
+type InlineCommentAnchor struct {
+	Line     int    `json:"line"`
+	Path    string `json:"path"`
+	LineType string `json:"lineType"` // ADDED, REMOVED, or CONTEXT
+}
+
+// Comment represents a pull request comment returned by the API.
+type Comment struct {
+	ID      int64  `json:"id"`
+	Version int    `json:"version"`
+	Text    string `json:"text"`
+	Author  struct {
+		Name        string `json:"name"`
+		DisplayName string `json:"displayName"`
+		Slug        string `json:"slug"`
+	} `json:"author"`
+}
+
+// AddComment adds a general comment to a pull request.
+// If parentID > 0, the comment is posted as a reply to that comment.
+func (service *Service) AddComment(ctx context.Context, repository RepositoryRef, pullRequestID string, text string, parentID int64) (Comment, error) {
+	if err := validateRepositoryRef(repository); err != nil {
+		return Comment{}, err
+	}
+	resolvedID, err := normalizePullRequestID(pullRequestID)
+	if err != nil {
+		return Comment{}, err
+	}
+	trimmedText := strings.TrimSpace(text)
+	if trimmedText == "" {
+		return Comment{}, apperrors.New(apperrors.KindValidation, "comment text is required", nil)
+	}
+	path := fmt.Sprintf("%s/%s/comments", pullRequestPath(repository), resolvedID)
+	payload := map[string]any{"text": trimmedText}
+	if parentID > 0 {
+		payload["parent"] = map[string]any{"id": parentID}
+	}
+	var result Comment
+	if err := service.client.PostJSON(ctx, path, nil, payload, &result); err != nil {
+		return Comment{}, err
+	}
+	return result, nil
+}
+
+// AddInlineComment adds a comment on a specific line of a file in a pull request diff.
+func (service *Service) AddInlineComment(ctx context.Context, repository RepositoryRef, pullRequestID string, text string, anchor InlineCommentAnchor) (Comment, error) {
+	if err := validateRepositoryRef(repository); err != nil {
+		return Comment{}, err
+	}
+	resolvedID, err := normalizePullRequestID(pullRequestID)
+	if err != nil {
+		return Comment{}, err
+	}
+	trimmedText := strings.TrimSpace(text)
+	if trimmedText == "" {
+		return Comment{}, apperrors.New(apperrors.KindValidation, "comment text is required", nil)
+	}
+	if anchor.Path == "" {
+		return Comment{}, apperrors.New(apperrors.KindValidation, "file path is required for inline comments", nil)
+	}
+	if anchor.Line <= 0 {
+		return Comment{}, apperrors.New(apperrors.KindValidation, "line must be a positive integer", nil)
+	}
+	lineType := strings.ToUpper(strings.TrimSpace(anchor.LineType))
+	if lineType == "" {
+		lineType = "ADDED"
+	}
+	path := fmt.Sprintf("%s/%s/comments", pullRequestPath(repository), resolvedID)
+	payload := map[string]any{
+		"text": trimmedText,
+		"anchor": map[string]any{
+			"line":     anchor.Line,
+			"path":    anchor.Path,
+			"lineType": lineType,
+		},
+	}
+	var result Comment
+	if err := service.client.PostJSON(ctx, path, nil, payload, &result); err != nil {
+		return Comment{}, err
+	}
+	return result, nil
 }
 
 func (service *Service) AddReviewer(ctx context.Context, repository RepositoryRef, pullRequestID string, username string) (PullRequest, error) {
@@ -796,7 +913,7 @@ func mapPullRequest(raw pullRequestValue) PullRequest {
 		SourceCommit: sourceCommit(raw.FromRef),
 		CreatedDate:  raw.CreatedDate,
 		UpdatedDate:  raw.UpdatedDate,
-		Reviewers:    mapReviewers(raw.Participants),
+		Reviewers:    mapReviewers(raw.Participants, raw.Reviewers),
 	}
 
 	if raw.ToRef != nil && raw.ToRef.Repository != nil {
@@ -809,13 +926,21 @@ func mapPullRequest(raw pullRequestValue) PullRequest {
 	return pr
 }
 
-func mapReviewers(participants []pullRequestParticipant) []Reviewer {
-	if len(participants) == 0 {
+// mapReviewers maps PR participants to reviewers. On Bitbucket Data Center 9.4.16,
+// the PR response "participants" field is always empty; only "reviewers" contains
+// the assigned reviewers with their approval status. Falls back to "reviewers"
+// when "participants" is empty. Filters out role=="author" as a safety net.
+func mapReviewers(participants []pullRequestParticipant, reviewers []pullRequestParticipant) []Reviewer {
+	raw := participants
+	if len(raw) == 0 {
+		raw = reviewers
+	}
+	if len(raw) == 0 {
 		return nil
 	}
 
-	reviewers := make([]Reviewer, 0, len(participants))
-	for _, participant := range participants {
+	result := make([]Reviewer, 0, len(raw))
+	for _, participant := range raw {
 		if participant.User == nil {
 			continue
 		}
@@ -833,14 +958,14 @@ func mapReviewers(participants []pullRequestParticipant) []Reviewer {
 			continue
 		}
 
-		reviewers = append(reviewers, reviewer)
+		result = append(result, reviewer)
 	}
 
-	if len(reviewers) == 0 {
+	if len(result) == 0 {
 		return nil
 	}
 
-	return reviewers
+	return result
 }
 
 func mapMergeability(raw mergeabilityValue) Mergeability {
@@ -1155,6 +1280,7 @@ type pullRequestValue struct {
 	UpdatedDate  int64                    `json:"updatedDate"`
 	Author       *pullRequestUser         `json:"author"`
 	Participants []pullRequestParticipant `json:"participants"`
+	Reviewers    []pullRequestParticipant `json:"reviewers"`
 	FromRef      *pullRequestRef          `json:"fromRef"`
 	ToRef        *pullRequestRef          `json:"toRef"`
 }

--- a/internal/services/pullrequest/service.go
+++ b/internal/services/pullrequest/service.go
@@ -128,7 +128,6 @@ func (service *Service) WithAPIClient(apiClient *openapigenerated.ClientWithResp
 	return service
 }
 
-
 type DashboardListOptions struct {
 	State string
 	Role  string
@@ -395,9 +394,10 @@ func (service *Service) Unapprove(ctx context.Context, repository RepositoryRef,
 	return mapPullRequest(response), nil
 }
 
-// NeedsWork sets the current user's review status to NEEDS_WORK on a pull request.
-// Uses PUT .../participants/{userSlug} with {"status": "NEEDS_WORK"}.
-// The userSlug is resolved by posting a temporary comment and reading the author from the response.
+// NeedsWork sets the current user's review status to NEEDS_WORK on a pull
+// request, the equivalent of "request changes". Unlike approve and unapprove
+// there is no dedicated endpoint, so this updates the participant record
+// directly via PUT .../participants/{userSlug}.
 func (service *Service) NeedsWork(ctx context.Context, repository RepositoryRef, pullRequestID string) (PullRequest, error) {
 	if err := validateRepositoryRef(repository); err != nil {
 		return PullRequest{}, err
@@ -427,7 +427,7 @@ func (service *Service) NeedsWork(ctx context.Context, repository RepositoryRef,
 // InlineCommentAnchor specifies the file location for an inline PR comment.
 type InlineCommentAnchor struct {
 	Line     int    `json:"line"`
-	Path    string `json:"path"`
+	Path     string `json:"path"`
 	LineType string `json:"lineType"` // ADDED, REMOVED, or CONTEXT
 }
 
@@ -444,68 +444,110 @@ type Comment struct {
 }
 
 // AddComment adds a general comment to a pull request.
-// If parentID > 0, the comment is posted as a reply to that comment.
+// If parentID is greater than zero the comment is posted as a reply to it.
 func (service *Service) AddComment(ctx context.Context, repository RepositoryRef, pullRequestID string, text string, parentID int64) (Comment, error) {
 	if err := validateRepositoryRef(repository); err != nil {
 		return Comment{}, err
 	}
+
 	resolvedID, err := normalizePullRequestID(pullRequestID)
 	if err != nil {
 		return Comment{}, err
 	}
+
 	trimmedText := strings.TrimSpace(text)
 	if trimmedText == "" {
 		return Comment{}, apperrors.New(apperrors.KindValidation, "comment text is required", nil)
 	}
-	path := fmt.Sprintf("%s/%s/comments", pullRequestPath(repository), resolvedID)
+
 	payload := map[string]any{"text": trimmedText}
 	if parentID > 0 {
 		payload["parent"] = map[string]any{"id": parentID}
 	}
+
+	path := fmt.Sprintf("%s/%s/comments", pullRequestPath(repository), resolvedID)
+
 	var result Comment
 	if err := service.client.PostJSON(ctx, path, nil, payload, &result); err != nil {
 		return Comment{}, err
 	}
+
 	return result, nil
 }
 
-// AddInlineComment adds a comment on a specific line of a file in a pull request diff.
+// AddInlineComment adds a comment on a specific line of a file in a pull
+// request diff.
 func (service *Service) AddInlineComment(ctx context.Context, repository RepositoryRef, pullRequestID string, text string, anchor InlineCommentAnchor) (Comment, error) {
 	if err := validateRepositoryRef(repository); err != nil {
 		return Comment{}, err
 	}
+
 	resolvedID, err := normalizePullRequestID(pullRequestID)
 	if err != nil {
 		return Comment{}, err
 	}
+
 	trimmedText := strings.TrimSpace(text)
 	if trimmedText == "" {
 		return Comment{}, apperrors.New(apperrors.KindValidation, "comment text is required", nil)
 	}
-	if anchor.Path == "" {
+
+	trimmedPath := strings.TrimSpace(anchor.Path)
+	if trimmedPath == "" {
 		return Comment{}, apperrors.New(apperrors.KindValidation, "file path is required for inline comments", nil)
 	}
+
 	if anchor.Line <= 0 {
 		return Comment{}, apperrors.New(apperrors.KindValidation, "line must be a positive integer", nil)
 	}
-	lineType := strings.ToUpper(strings.TrimSpace(anchor.LineType))
-	if lineType == "" {
-		lineType = "ADDED"
+
+	lineType, err := normalizeLineType(anchor.LineType)
+	if err != nil {
+		return Comment{}, err
 	}
-	path := fmt.Sprintf("%s/%s/comments", pullRequestPath(repository), resolvedID)
+
+	// fileType selects which side of the diff the line number refers to:
+	// removed lines only exist in the original file, everything else is
+	// anchored against the updated one. diffType EFFECTIVE anchors the comment
+	// against the pull request diff rather than a single commit.
+	fileType := "TO"
+	if lineType == "REMOVED" {
+		fileType = "FROM"
+	}
+
 	payload := map[string]any{
 		"text": trimmedText,
 		"anchor": map[string]any{
 			"line":     anchor.Line,
-			"path":    anchor.Path,
+			"path":     trimmedPath,
 			"lineType": lineType,
+			"fileType": fileType,
+			"diffType": "EFFECTIVE",
 		},
 	}
+
+	path := fmt.Sprintf("%s/%s/comments", pullRequestPath(repository), resolvedID)
+
 	var result Comment
 	if err := service.client.PostJSON(ctx, path, nil, payload, &result); err != nil {
 		return Comment{}, err
 	}
+
 	return result, nil
+}
+
+// normalizeLineType validates the diff side an inline comment anchors to,
+// defaulting to ADDED when unset.
+func normalizeLineType(lineType string) (string, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(lineType))
+	switch normalized {
+	case "":
+		return "ADDED", nil
+	case "ADDED", "REMOVED", "CONTEXT":
+		return normalized, nil
+	default:
+		return "", apperrors.New(apperrors.KindValidation, "line_type must be one of ADDED, REMOVED, or CONTEXT", nil)
+	}
 }
 
 func (service *Service) AddReviewer(ctx context.Context, repository RepositoryRef, pullRequestID string, username string) (PullRequest, error) {
@@ -1563,4 +1605,3 @@ func (service *Service) SearchParticipants(ctx context.Context, repository Repos
 	}
 	return results, nil
 }
-

--- a/internal/services/pullrequest/service_test.go
+++ b/internal/services/pullrequest/service_test.go
@@ -175,7 +175,7 @@ func TestPullRequestLifecycleReviewAndTaskOperations(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		switch {
 		case request.Method == http.MethodGet && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/22":
-			_, _ = fmt.Fprint(w, `{"id":22,"title":"Feature","state":"OPEN","open":true,"closed":false,"version":2,"participants":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1","displayName":"Reviewer One"}}],"fromRef":{"displayId":"feature/a"},"toRef":{"displayId":"master"}}`)
+			_, _ = fmt.Fprint(w, `{"id":22,"title":"Feature","state":"OPEN","open":true,"closed":false,"version":2,"reviewers":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1","displayName":"Reviewer One"}}],"fromRef":{"displayId":"feature/a"},"toRef":{"displayId":"master"}}`)
 		case request.Method == http.MethodGet && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/22/merge":
 			_, _ = fmt.Fprint(w, `{"conflicted":false,"outcome":"CLEAN","vetoes":[]}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests":
@@ -199,13 +199,13 @@ func TestPullRequestLifecycleReviewAndTaskOperations(t *testing.T) {
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/reopen":
 			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/approve":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"APPROVED","approved":true,"user":{"name":"reviewer1"}}]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[{"role":"REVIEWER","status":"APPROVED","approved":true,"user":{"name":"reviewer1"}}]}`)
 		case request.Method == http.MethodDelete && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/approve":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1"}}]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1"}}]}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer2"}}]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer2"}}]}`)
 		case request.Method == http.MethodDelete && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants/reviewer2":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[]}`)
 		case request.Method == http.MethodGet && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/tasks":
 			_, _ = fmt.Fprint(w, `{"isLastPage":true,"nextPageStart":0,"values":[{"id":500,"text":"Open task","state":"OPEN","resolved":false},{"id":501,"text":"Resolved task","state":"RESOLVED","resolved":true}]}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/tasks":

--- a/internal/services/pullrequest/service_test.go
+++ b/internal/services/pullrequest/service_test.go
@@ -2,6 +2,7 @@ package pullrequest
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -175,7 +176,7 @@ func TestPullRequestLifecycleReviewAndTaskOperations(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		switch {
 		case request.Method == http.MethodGet && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/22":
-			_, _ = fmt.Fprint(w, `{"id":22,"title":"Feature","state":"OPEN","open":true,"closed":false,"version":2,"reviewers":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1","displayName":"Reviewer One"}}],"fromRef":{"displayId":"feature/a"},"toRef":{"displayId":"master"}}`)
+			_, _ = fmt.Fprint(w, `{"id":22,"title":"Feature","state":"OPEN","open":true,"closed":false,"version":2,"participants":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1","displayName":"Reviewer One"}}],"fromRef":{"displayId":"feature/a"},"toRef":{"displayId":"master"}}`)
 		case request.Method == http.MethodGet && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/22/merge":
 			_, _ = fmt.Fprint(w, `{"conflicted":false,"outcome":"CLEAN","vetoes":[]}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests":
@@ -199,13 +200,13 @@ func TestPullRequestLifecycleReviewAndTaskOperations(t *testing.T) {
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/reopen":
 			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/approve":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[{"role":"REVIEWER","status":"APPROVED","approved":true,"user":{"name":"reviewer1"}}]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"APPROVED","approved":true,"user":{"name":"reviewer1"}}]}`)
 		case request.Method == http.MethodDelete && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/approve":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1"}}]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer1"}}]}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer2"}}]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"UNAPPROVED","approved":false,"user":{"name":"reviewer2"}}]}`)
 		case request.Method == http.MethodDelete && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/participants/reviewer2":
-			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"reviewers":[]}`)
+			_, _ = fmt.Fprint(w, `{"id":30,"title":"Updated PR","state":"OPEN","open":true,"closed":false,"participants":[]}`)
 		case request.Method == http.MethodGet && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/tasks":
 			_, _ = fmt.Fprint(w, `{"isLastPage":true,"nextPageStart":0,"values":[{"id":500,"text":"Open task","state":"OPEN","resolved":false},{"id":501,"text":"Resolved task","state":"RESOLVED","resolved":true}]}`)
 		case request.Method == http.MethodPost && request.URL.Path == "/rest/api/latest/projects/TEST/repos/demo/pull-requests/30/tasks":
@@ -1375,3 +1376,359 @@ func TestListPullRequestsContainingCommitAndSearchParticipantsAPIErrors(t *testi
 	}
 }
 
+// newCommentTestService wires a service against a test server and captures the
+// decoded request body of the last write it received.
+func newCommentTestService(t *testing.T, handler func(w http.ResponseWriter, request *http.Request)) *Service {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	t.Setenv("BITBUCKET_URL", server.URL)
+	t.Setenv("BITBUCKET_PROJECT_KEY", "TEST")
+
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	return NewService(httpclient.NewFromConfig(cfg))
+}
+
+func TestNeedsWorkSetsParticipantStatus(t *testing.T) {
+	var gotPath string
+	var gotMethod string
+	var gotPayload map[string]any
+
+	service := newCommentTestService(t, func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/rest/api/latest/users" {
+			w.Header().Set("X-AUSERNAME", "alice")
+			_, _ = fmt.Fprint(w, `{"values":[]}`)
+			return
+		}
+
+		gotPath = request.URL.Path
+		gotMethod = request.Method
+		body, _ := io.ReadAll(request.Body)
+		_ = json.Unmarshal(body, &gotPayload)
+
+		_, _ = fmt.Fprint(w, `{"id":42,"title":"Feature","state":"OPEN","open":true,"closed":false,"participants":[{"role":"REVIEWER","status":"NEEDS_WORK","approved":false,"user":{"name":"alice"}}]}`)
+	})
+
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+
+	pr, err := service.NeedsWork(context.Background(), repo, "42")
+	if err != nil {
+		t.Fatalf("expected needs work success, got %v", err)
+	}
+
+	if gotMethod != http.MethodPut {
+		t.Fatalf("expected PUT, got %s", gotMethod)
+	}
+	wantPath := "/rest/api/latest/projects/TEST/repos/demo/pull-requests/42/participants/alice"
+	if gotPath != wantPath {
+		t.Fatalf("expected path %q, got %q", wantPath, gotPath)
+	}
+	if gotPayload["status"] != "NEEDS_WORK" {
+		t.Fatalf("expected NEEDS_WORK status payload, got %#v", gotPayload)
+	}
+	if len(pr.Reviewers) != 1 || pr.Reviewers[0].Status != "NEEDS_WORK" {
+		t.Fatalf("expected mapped NEEDS_WORK reviewer, got %#v", pr.Reviewers)
+	}
+}
+
+func TestNeedsWorkValidation(t *testing.T) {
+	service := newCommentTestService(t, func(w http.ResponseWriter, request *http.Request) {
+		t.Errorf("server must not be reached, got %s", request.URL.Path)
+	})
+
+	if _, err := service.NeedsWork(context.Background(), RepositoryRef{}, "42"); err == nil {
+		t.Fatal("expected repository validation error")
+	}
+	if _, err := service.NeedsWork(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, "not-a-number"); err == nil {
+		t.Fatal("expected pull request id validation error")
+	}
+}
+
+func TestNeedsWorkPropagatesUserLookupFailure(t *testing.T) {
+	service := newCommentTestService(t, func(w http.ResponseWriter, request *http.Request) {
+		// No X-AUSERNAME header: the slug cannot be resolved.
+		_, _ = fmt.Fprint(w, `{"values":[]}`)
+	})
+
+	_, err := service.NeedsWork(context.Background(), RepositoryRef{ProjectKey: "TEST", Slug: "demo"}, "42")
+	if err == nil || !strings.Contains(err.Error(), "X-AUSERNAME") {
+		t.Fatalf("expected the user lookup failure to propagate, got %v", err)
+	}
+}
+
+func TestAddCommentPlainAndReply(t *testing.T) {
+	var gotPath string
+	var gotPayload map[string]any
+
+	service := newCommentTestService(t, func(w http.ResponseWriter, request *http.Request) {
+		gotPath = request.URL.Path
+		body, _ := io.ReadAll(request.Body)
+		gotPayload = map[string]any{}
+		_ = json.Unmarshal(body, &gotPayload)
+		_, _ = fmt.Fprint(w, `{"id":900,"version":0,"text":"looks good","author":{"name":"alice","displayName":"Alice","slug":"alice"}}`)
+	})
+
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+
+	comment, err := service.AddComment(context.Background(), repo, "42", "  looks good  ", 0)
+	if err != nil {
+		t.Fatalf("expected comment success, got %v", err)
+	}
+	if gotPath != "/rest/api/latest/projects/TEST/repos/demo/pull-requests/42/comments" {
+		t.Fatalf("unexpected path %q", gotPath)
+	}
+	if gotPayload["text"] != "looks good" {
+		t.Fatalf("expected trimmed text, got %#v", gotPayload["text"])
+	}
+	if _, hasParent := gotPayload["parent"]; hasParent {
+		t.Fatalf("expected no parent for a top level comment, got %#v", gotPayload)
+	}
+	if comment.ID != 900 || comment.Author.Slug != "alice" {
+		t.Fatalf("expected decoded comment, got %#v", comment)
+	}
+
+	if _, err := service.AddComment(context.Background(), repo, "42", "replying", 900); err != nil {
+		t.Fatalf("expected reply success, got %v", err)
+	}
+	parent, ok := gotPayload["parent"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected parent object on a reply, got %#v", gotPayload)
+	}
+	if id, _ := parent["id"].(float64); int64(id) != 900 {
+		t.Fatalf("expected parent id 900, got %#v", parent["id"])
+	}
+}
+
+func TestAddCommentValidation(t *testing.T) {
+	service := newCommentTestService(t, func(w http.ResponseWriter, request *http.Request) {
+		t.Errorf("server must not be reached, got %s", request.URL.Path)
+	})
+
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+
+	if _, err := service.AddComment(context.Background(), RepositoryRef{}, "42", "text", 0); err == nil {
+		t.Fatal("expected repository validation error")
+	}
+	if _, err := service.AddComment(context.Background(), repo, "nope", "text", 0); err == nil {
+		t.Fatal("expected pull request id validation error")
+	}
+	if _, err := service.AddComment(context.Background(), repo, "42", "   ", 0); err == nil {
+		t.Fatal("expected empty text validation error")
+	}
+}
+
+func TestAddInlineCommentBuildsAnchor(t *testing.T) {
+	var gotPayload map[string]any
+
+	service := newCommentTestService(t, func(w http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		gotPayload = map[string]any{}
+		_ = json.Unmarshal(body, &gotPayload)
+		_, _ = fmt.Fprint(w, `{"id":901,"version":0,"text":"nit"}`)
+	})
+
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+
+	if _, err := service.AddInlineComment(context.Background(), repo, "42", "nit", InlineCommentAnchor{
+		Line: 12,
+		Path: " src/main.go ",
+	}); err != nil {
+		t.Fatalf("expected inline comment success, got %v", err)
+	}
+
+	anchor, ok := gotPayload["anchor"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected an anchor object, got %#v", gotPayload)
+	}
+	if line, _ := anchor["line"].(float64); int(line) != 12 {
+		t.Fatalf("expected line 12, got %#v", anchor["line"])
+	}
+	if anchor["path"] != "src/main.go" {
+		t.Fatalf("expected trimmed path, got %#v", anchor["path"])
+	}
+	if anchor["lineType"] != "ADDED" {
+		t.Fatalf("expected ADDED to be the default lineType, got %#v", anchor["lineType"])
+	}
+	if anchor["fileType"] != "TO" {
+		t.Fatalf("expected fileType TO for an added line, got %#v", anchor["fileType"])
+	}
+	if anchor["diffType"] != "EFFECTIVE" {
+		t.Fatalf("expected diffType EFFECTIVE, got %#v", anchor["diffType"])
+	}
+}
+
+func TestAddInlineCommentRemovedLineAnchorsToOriginalFile(t *testing.T) {
+	var gotPayload map[string]any
+
+	service := newCommentTestService(t, func(w http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		gotPayload = map[string]any{}
+		_ = json.Unmarshal(body, &gotPayload)
+		_, _ = fmt.Fprint(w, `{"id":902}`)
+	})
+
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+
+	if _, err := service.AddInlineComment(context.Background(), repo, "42", "why drop this?", InlineCommentAnchor{
+		Line:     3,
+		Path:     "src/main.go",
+		LineType: "removed",
+	}); err != nil {
+		t.Fatalf("expected inline comment success, got %v", err)
+	}
+
+	anchor, _ := gotPayload["anchor"].(map[string]any)
+	if anchor["lineType"] != "REMOVED" {
+		t.Fatalf("expected lineType to be upper-cased to REMOVED, got %#v", anchor["lineType"])
+	}
+	if anchor["fileType"] != "FROM" {
+		t.Fatalf("expected fileType FROM for a removed line, got %#v", anchor["fileType"])
+	}
+}
+
+func TestAddInlineCommentValidation(t *testing.T) {
+	service := newCommentTestService(t, func(w http.ResponseWriter, request *http.Request) {
+		t.Errorf("server must not be reached, got %s", request.URL.Path)
+	})
+
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+	valid := InlineCommentAnchor{Line: 1, Path: "a.go"}
+
+	cases := []struct {
+		name   string
+		repo   RepositoryRef
+		prID   string
+		text   string
+		anchor InlineCommentAnchor
+	}{
+		{name: "bad repository", repo: RepositoryRef{}, prID: "42", text: "t", anchor: valid},
+		{name: "bad pull request id", repo: repo, prID: "nope", text: "t", anchor: valid},
+		{name: "empty text", repo: repo, prID: "42", text: "  ", anchor: valid},
+		{name: "missing path", repo: repo, prID: "42", text: "t", anchor: InlineCommentAnchor{Line: 1, Path: "  "}},
+		{name: "zero line", repo: repo, prID: "42", text: "t", anchor: InlineCommentAnchor{Line: 0, Path: "a.go"}},
+		{name: "negative line", repo: repo, prID: "42", text: "t", anchor: InlineCommentAnchor{Line: -3, Path: "a.go"}},
+		{name: "unknown line type", repo: repo, prID: "42", text: "t", anchor: InlineCommentAnchor{Line: 1, Path: "a.go", LineType: "SIDEWAYS"}},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := service.AddInlineComment(context.Background(), testCase.repo, testCase.prID, testCase.text, testCase.anchor)
+			if err == nil {
+				t.Fatal("expected a validation error")
+			}
+			if apperrors.ExitCode(err) != 2 {
+				t.Fatalf("expected validation exit code 2, got %d: %v", apperrors.ExitCode(err), err)
+			}
+		})
+	}
+}
+
+func TestNormalizeLineType(t *testing.T) {
+	cases := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{input: "", want: "ADDED"},
+		{input: "   ", want: "ADDED"},
+		{input: "added", want: "ADDED"},
+		{input: " Removed ", want: "REMOVED"},
+		{input: "CONTEXT", want: "CONTEXT"},
+		{input: "bogus", wantErr: true},
+	}
+
+	for _, testCase := range cases {
+		got, err := normalizeLineType(testCase.input)
+		if testCase.wantErr {
+			if err == nil {
+				t.Fatalf("expected error for %q", testCase.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", testCase.input, err)
+		}
+		if got != testCase.want {
+			t.Fatalf("normalizeLineType(%q) = %q, want %q", testCase.input, got, testCase.want)
+		}
+	}
+}
+
+// TestMapReviewersPrefersParticipants pins the fallback behaviour: Bitbucket
+// Data Center 9.4.16 returns an empty "participants" array and populates
+// "reviewers" instead, but servers that do populate "participants" must keep
+// working from that field.
+func TestMapReviewersPrefersParticipants(t *testing.T) {
+	participant := pullRequestParticipant{
+		Role:     "REVIEWER",
+		Status:   "APPROVED",
+		Approved: true,
+		User:     &pullRequestUserIdentity{Name: "from-participants"},
+	}
+	reviewer := pullRequestParticipant{
+		Role:     "REVIEWER",
+		Status:   "UNAPPROVED",
+		Approved: false,
+		User:     &pullRequestUserIdentity{Name: "from-reviewers"},
+	}
+
+	t.Run("participants win when present", func(t *testing.T) {
+		got := mapReviewers([]pullRequestParticipant{participant}, []pullRequestParticipant{reviewer})
+		if len(got) != 1 || got[0].Name != "from-participants" {
+			t.Fatalf("expected participants to take precedence, got %#v", got)
+		}
+	})
+
+	t.Run("reviewers used when participants empty", func(t *testing.T) {
+		got := mapReviewers(nil, []pullRequestParticipant{reviewer})
+		if len(got) != 1 || got[0].Name != "from-reviewers" {
+			t.Fatalf("expected the reviewers fallback, got %#v", got)
+		}
+	})
+
+	t.Run("both empty", func(t *testing.T) {
+		if got := mapReviewers(nil, nil); got != nil {
+			t.Fatalf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("authors filtered out", func(t *testing.T) {
+		author := pullRequestParticipant{
+			Role: "AUTHOR",
+			User: &pullRequestUserIdentity{Name: "author"},
+		}
+		if got := mapReviewers(nil, []pullRequestParticipant{author}); got != nil {
+			t.Fatalf("expected authors to be filtered out, got %#v", got)
+		}
+	})
+
+	t.Run("entries without a user skipped", func(t *testing.T) {
+		if got := mapReviewers([]pullRequestParticipant{{Role: "REVIEWER"}}, nil); got != nil {
+			t.Fatalf("expected entries without a user to be skipped, got %#v", got)
+		}
+	})
+}
+
+func TestListPullRequestsAppliesRoleFilter(t *testing.T) {
+	var gotRole string
+
+	service := newCommentTestService(t, func(w http.ResponseWriter, request *http.Request) {
+		gotRole = request.URL.Query().Get("role")
+		_, _ = fmt.Fprint(w, `{"values":[],"isLastPage":true}`)
+	})
+
+	repo := RepositoryRef{ProjectKey: "TEST", Slug: "demo"}
+
+	if _, err := service.List(context.Background(), repo, ListOptions{Role: "reviewer", Limit: 5}); err != nil {
+		t.Fatalf("expected list success, got %v", err)
+	}
+	if gotRole != "REVIEWER" {
+		t.Fatalf("expected role to be upper-cased to REVIEWER, got %q", gotRole)
+	}
+}

--- a/internal/transport/httpclient/client.go
+++ b/internal/transport/httpclient/client.go
@@ -69,6 +69,39 @@ func (client *Client) GetJSON(ctx context.Context, path string, query map[string
 	return client.doJSON(ctx, http.MethodGet, path, query, nil, out)
 }
 
+// CurrentUserSlug returns the authenticated user's slug by reading the
+// X-AUSERNAME response header from a lightweight API request.
+func (client *Client) CurrentUserSlug(ctx context.Context) (string, error) {
+	if client.initErr != nil {
+		return "", apperrors.New(apperrors.KindValidation, "failed to initialize HTTP transport", client.initErr)
+	}
+
+	requestURL, err := url.Parse(client.baseURL + "/rest/api/latest/users")
+	if err != nil {
+		return "", apperrors.New(apperrors.KindValidation, "invalid request URL", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return "", apperrors.New(apperrors.KindInternal, "failed to build request", err)
+	}
+	request.Header.Set("Accept", "application/json")
+	client.applyAuth(request)
+
+	response, err := client.http.Do(request)
+	if err != nil {
+		return "", apperrors.New(apperrors.KindTransient, "request failed", err)
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, response.Body)
+
+	slug := strings.TrimSpace(response.Header.Get("X-AUSERNAME"))
+	if slug == "" {
+		return "", apperrors.New(apperrors.KindAuthentication, "X-AUSERNAME header not found in response", nil)
+	}
+	return slug, nil
+}
+
 func (client *Client) PostJSON(ctx context.Context, path string, query map[string]string, in any, out any) error {
 	return client.doJSON(ctx, http.MethodPost, path, query, in, out)
 }
@@ -79,6 +112,108 @@ func (client *Client) PutJSON(ctx context.Context, path string, query map[string
 
 func (client *Client) DeleteJSON(ctx context.Context, path string, query map[string]string, in any, out any) error {
 	return client.doJSON(ctx, http.MethodDelete, path, query, in, out)
+}
+
+// GetRaw performs a GET request and returns the raw response body as bytes.
+// Unlike GetJSON, it does not set Accept: application/json or attempt to unmarshal.
+func (client *Client) GetRaw(ctx context.Context, path string, query map[string]string) ([]byte, error) {
+	if client.initErr != nil {
+		return nil, apperrors.New(apperrors.KindValidation, "failed to initialize HTTP transport", client.initErr)
+	}
+
+	requestURL, err := url.Parse(client.baseURL + path)
+	if err != nil {
+		return nil, apperrors.New(apperrors.KindValidation, "invalid request URL", err)
+	}
+
+	values := requestURL.Query()
+	for key, value := range query {
+		values.Set(key, value)
+	}
+	requestURL.RawQuery = values.Encode()
+
+	var lastErr error
+	for attempt := 0; attempt <= client.retries; attempt++ {
+		started := time.Now()
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+		if err != nil {
+			return nil, apperrors.New(apperrors.KindInternal, "failed to build request", err)
+		}
+		client.applyAuth(request)
+
+		response, err := client.http.Do(request)
+		if err != nil {
+			fields := map[string]any{
+				"method":      http.MethodGet,
+				"endpoint":    requestURL.Path,
+				"attempt":     attempt + 1,
+				"retry_count": client.retries,
+				"duration_ms": time.Since(started).Milliseconds(),
+				"error":       err.Error(),
+			}
+			lastErr = apperrors.New(apperrors.KindTransient, "request failed", err)
+			if attempt < client.retries {
+				client.logger.Warn("http request failed", fields)
+				if sleepErr := sleepWithContext(ctx, time.Duration(attempt+1)*client.backoff); sleepErr != nil {
+					return nil, apperrors.New(apperrors.KindTransient, "request canceled while waiting to retry", sleepErr)
+				}
+				continue
+			}
+			client.logger.Error("http request failed", fields)
+			return nil, lastErr
+		}
+
+		body, readErr := io.ReadAll(response.Body)
+		_ = response.Body.Close()
+		if readErr != nil {
+			return nil, apperrors.New(apperrors.KindTransient, "failed to read response", readErr)
+		}
+
+		if response.StatusCode >= 200 && response.StatusCode < 300 {
+			client.logger.Debug("http request completed", map[string]any{
+				"method":      http.MethodGet,
+				"endpoint":    requestURL.Path,
+				"status":      response.StatusCode,
+				"attempt":     attempt + 1,
+				"retry_count": client.retries,
+				"duration_ms": time.Since(started).Milliseconds(),
+			})
+			return body, nil
+		}
+
+		mappedErr := openapi.MapStatusError(response.StatusCode, body)
+		fields := map[string]any{
+			"method":      http.MethodGet,
+			"endpoint":    requestURL.Path,
+			"status":      response.StatusCode,
+			"attempt":     attempt + 1,
+			"retry_count": client.retries,
+			"duration_ms": time.Since(started).Milliseconds(),
+			"error":       mappedErr.Error(),
+		}
+		if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
+			lastErr = mappedErr
+			retryDelay := retryDelayFromResponse(response.Header, attempt, client.backoff)
+			fields["retry_delay"] = retryDelay.String()
+			if attempt < client.retries {
+				client.logger.Warn("http request returned error status", fields)
+				if sleepErr := sleepWithContext(ctx, retryDelay); sleepErr != nil {
+					return nil, apperrors.New(apperrors.KindTransient, "request canceled while waiting to retry", sleepErr)
+				}
+				continue
+			}
+			client.logger.Error("http request returned error status", fields)
+			return nil, lastErr
+		}
+
+		client.logger.Error("http request returned error status", fields)
+		return nil, mappedErr
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, apperrors.New(apperrors.KindTransient, "request failed after retries", nil)
 }
 
 func (client *Client) doJSON(ctx context.Context, method string, path string, query map[string]string, in any, out any) error {

--- a/internal/transport/httpclient/client.go
+++ b/internal/transport/httpclient/client.go
@@ -69,39 +69,6 @@ func (client *Client) GetJSON(ctx context.Context, path string, query map[string
 	return client.doJSON(ctx, http.MethodGet, path, query, nil, out)
 }
 
-// CurrentUserSlug returns the authenticated user's slug by reading the
-// X-AUSERNAME response header from a lightweight API request.
-func (client *Client) CurrentUserSlug(ctx context.Context) (string, error) {
-	if client.initErr != nil {
-		return "", apperrors.New(apperrors.KindValidation, "failed to initialize HTTP transport", client.initErr)
-	}
-
-	requestURL, err := url.Parse(client.baseURL + "/rest/api/latest/users")
-	if err != nil {
-		return "", apperrors.New(apperrors.KindValidation, "invalid request URL", err)
-	}
-
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
-	if err != nil {
-		return "", apperrors.New(apperrors.KindInternal, "failed to build request", err)
-	}
-	request.Header.Set("Accept", "application/json")
-	client.applyAuth(request)
-
-	response, err := client.http.Do(request)
-	if err != nil {
-		return "", apperrors.New(apperrors.KindTransient, "request failed", err)
-	}
-	defer response.Body.Close()
-	_, _ = io.Copy(io.Discard, response.Body)
-
-	slug := strings.TrimSpace(response.Header.Get("X-AUSERNAME"))
-	if slug == "" {
-		return "", apperrors.New(apperrors.KindAuthentication, "X-AUSERNAME header not found in response", nil)
-	}
-	return slug, nil
-}
-
 func (client *Client) PostJSON(ctx context.Context, path string, query map[string]string, in any, out any) error {
 	return client.doJSON(ctx, http.MethodPost, path, query, in, out)
 }
@@ -115,123 +82,34 @@ func (client *Client) DeleteJSON(ctx context.Context, path string, query map[str
 }
 
 // GetRaw performs a GET request and returns the raw response body as bytes.
-// Unlike GetJSON, it does not set Accept: application/json or attempt to unmarshal.
+// Unlike GetJSON it does not set Accept: application/json and does not attempt
+// to unmarshal the response, so it suits endpoints that stream file contents.
 func (client *Client) GetRaw(ctx context.Context, path string, query map[string]string) ([]byte, error) {
-	if client.initErr != nil {
-		return nil, apperrors.New(apperrors.KindValidation, "failed to initialize HTTP transport", client.initErr)
-	}
-
-	requestURL, err := url.Parse(client.baseURL + path)
+	body, _, err := client.do(ctx, http.MethodGet, path, query, nil, false)
 	if err != nil {
-		return nil, apperrors.New(apperrors.KindValidation, "invalid request URL", err)
+		return nil, err
+	}
+	return body, nil
+}
+
+// CurrentUserSlug returns the authenticated user's slug. Bitbucket echoes the
+// authenticated username in the X-AUSERNAME response header on every
+// authenticated request, so a cheap GET is enough to resolve it without the
+// side effects of writing anything to the server.
+func (client *Client) CurrentUserSlug(ctx context.Context) (string, error) {
+	_, header, err := client.do(ctx, http.MethodGet, "/rest/api/latest/users", map[string]string{"limit": "1"}, nil, true)
+	if err != nil {
+		return "", err
 	}
 
-	values := requestURL.Query()
-	for key, value := range query {
-		values.Set(key, value)
+	slug := strings.TrimSpace(header.Get("X-AUSERNAME"))
+	if slug == "" {
+		return "", apperrors.New(apperrors.KindAuthentication, "could not determine the authenticated user: no X-AUSERNAME header in the response", nil)
 	}
-	requestURL.RawQuery = values.Encode()
-
-	var lastErr error
-	for attempt := 0; attempt <= client.retries; attempt++ {
-		started := time.Now()
-		request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
-		if err != nil {
-			return nil, apperrors.New(apperrors.KindInternal, "failed to build request", err)
-		}
-		client.applyAuth(request)
-
-		response, err := client.http.Do(request)
-		if err != nil {
-			fields := map[string]any{
-				"method":      http.MethodGet,
-				"endpoint":    requestURL.Path,
-				"attempt":     attempt + 1,
-				"retry_count": client.retries,
-				"duration_ms": time.Since(started).Milliseconds(),
-				"error":       err.Error(),
-			}
-			lastErr = apperrors.New(apperrors.KindTransient, "request failed", err)
-			if attempt < client.retries {
-				client.logger.Warn("http request failed", fields)
-				if sleepErr := sleepWithContext(ctx, time.Duration(attempt+1)*client.backoff); sleepErr != nil {
-					return nil, apperrors.New(apperrors.KindTransient, "request canceled while waiting to retry", sleepErr)
-				}
-				continue
-			}
-			client.logger.Error("http request failed", fields)
-			return nil, lastErr
-		}
-
-		body, readErr := io.ReadAll(response.Body)
-		_ = response.Body.Close()
-		if readErr != nil {
-			return nil, apperrors.New(apperrors.KindTransient, "failed to read response", readErr)
-		}
-
-		if response.StatusCode >= 200 && response.StatusCode < 300 {
-			client.logger.Debug("http request completed", map[string]any{
-				"method":      http.MethodGet,
-				"endpoint":    requestURL.Path,
-				"status":      response.StatusCode,
-				"attempt":     attempt + 1,
-				"retry_count": client.retries,
-				"duration_ms": time.Since(started).Milliseconds(),
-			})
-			return body, nil
-		}
-
-		mappedErr := openapi.MapStatusError(response.StatusCode, body)
-		fields := map[string]any{
-			"method":      http.MethodGet,
-			"endpoint":    requestURL.Path,
-			"status":      response.StatusCode,
-			"attempt":     attempt + 1,
-			"retry_count": client.retries,
-			"duration_ms": time.Since(started).Milliseconds(),
-			"error":       mappedErr.Error(),
-		}
-		if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
-			lastErr = mappedErr
-			retryDelay := retryDelayFromResponse(response.Header, attempt, client.backoff)
-			fields["retry_delay"] = retryDelay.String()
-			if attempt < client.retries {
-				client.logger.Warn("http request returned error status", fields)
-				if sleepErr := sleepWithContext(ctx, retryDelay); sleepErr != nil {
-					return nil, apperrors.New(apperrors.KindTransient, "request canceled while waiting to retry", sleepErr)
-				}
-				continue
-			}
-			client.logger.Error("http request returned error status", fields)
-			return nil, lastErr
-		}
-
-		client.logger.Error("http request returned error status", fields)
-		return nil, mappedErr
-	}
-
-	if lastErr != nil {
-		return nil, lastErr
-	}
-	return nil, apperrors.New(apperrors.KindTransient, "request failed after retries", nil)
+	return slug, nil
 }
 
 func (client *Client) doJSON(ctx context.Context, method string, path string, query map[string]string, in any, out any) error {
-	if client.initErr != nil {
-		return apperrors.New(apperrors.KindValidation, "failed to initialize HTTP transport", client.initErr)
-	}
-
-	requestURL, err := url.Parse(client.baseURL + path)
-	if err != nil {
-		return apperrors.New(apperrors.KindValidation, "invalid request URL", err)
-	}
-
-	values := requestURL.Query()
-	for key, value := range query {
-		values.Set(key, value)
-	}
-	requestURL.RawQuery = values.Encode()
-
 	var payload []byte
 	if in != nil {
 		encoded, err := json.Marshal(in)
@@ -240,6 +118,41 @@ func (client *Client) doJSON(ctx context.Context, method string, path string, qu
 		}
 		payload = encoded
 	}
+
+	body, _, err := client.do(ctx, method, path, query, payload, true)
+	if err != nil {
+		return err
+	}
+
+	if out == nil || len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(body, out); err != nil {
+		return apperrors.New(apperrors.KindPermanent, "failed to decode API response", err)
+	}
+	return nil
+}
+
+// do issues a request under the client's retry, logging and error-mapping
+// policy and returns the response body together with its headers. It is the
+// single transport path shared by the JSON helpers and by GetRaw so that all
+// callers get identical retry and error semantics.
+func (client *Client) do(ctx context.Context, method string, path string, query map[string]string, payload []byte, acceptJSON bool) ([]byte, http.Header, error) {
+	if client.initErr != nil {
+		return nil, nil, apperrors.New(apperrors.KindValidation, "failed to initialize HTTP transport", client.initErr)
+	}
+
+	requestURL, err := url.Parse(client.baseURL + path)
+	if err != nil {
+		return nil, nil, apperrors.New(apperrors.KindValidation, "invalid request URL", err)
+	}
+
+	values := requestURL.Query()
+	for key, value := range query {
+		values.Set(key, value)
+	}
+	requestURL.RawQuery = values.Encode()
 
 	var lastErr error
 	for attempt := 0; attempt <= client.retries; attempt++ {
@@ -251,10 +164,12 @@ func (client *Client) doJSON(ctx context.Context, method string, path string, qu
 
 		request, err := http.NewRequestWithContext(ctx, method, requestURL.String(), bodyReader)
 		if err != nil {
-			return apperrors.New(apperrors.KindInternal, "failed to build request", err)
+			return nil, nil, apperrors.New(apperrors.KindInternal, "failed to build request", err)
 		}
 
-		request.Header.Set("Accept", "application/json")
+		if acceptJSON {
+			request.Header.Set("Accept", "application/json")
+		}
 		if payload != nil {
 			request.Header.Set("Content-Type", "application/json")
 		}
@@ -274,18 +189,18 @@ func (client *Client) doJSON(ctx context.Context, method string, path string, qu
 			if attempt < client.retries {
 				client.logger.Warn("http request failed", fields)
 				if sleepErr := sleepWithContext(ctx, time.Duration(attempt+1)*client.backoff); sleepErr != nil {
-					return apperrors.New(apperrors.KindTransient, "request canceled while waiting to retry", sleepErr)
+					return nil, nil, apperrors.New(apperrors.KindTransient, "request canceled while waiting to retry", sleepErr)
 				}
 				continue
 			}
 			client.logger.Error("http request failed", fields)
-			return lastErr
+			return nil, nil, lastErr
 		}
 
 		body, readErr := io.ReadAll(response.Body)
 		_ = response.Body.Close()
 		if readErr != nil {
-			return apperrors.New(apperrors.KindTransient, "failed to read response", readErr)
+			return nil, nil, apperrors.New(apperrors.KindTransient, "failed to read response", readErr)
 		}
 
 		if response.StatusCode >= 200 && response.StatusCode < 300 {
@@ -297,14 +212,7 @@ func (client *Client) doJSON(ctx context.Context, method string, path string, qu
 				"retry_count": client.retries,
 				"duration_ms": time.Since(started).Milliseconds(),
 			})
-			if out == nil || len(bytes.TrimSpace(body)) == 0 {
-				return nil
-			}
-
-			if err := json.Unmarshal(body, out); err != nil {
-				return apperrors.New(apperrors.KindPermanent, "failed to decode API response", err)
-			}
-			return nil
+			return body, response.Header, nil
 		}
 
 		mappedErr := openapi.MapStatusError(response.StatusCode, body)
@@ -324,24 +232,24 @@ func (client *Client) doJSON(ctx context.Context, method string, path string, qu
 			if attempt < client.retries {
 				client.logger.Warn("http request returned error status", fields)
 				if sleepErr := sleepWithContext(ctx, retryDelay); sleepErr != nil {
-					return apperrors.New(apperrors.KindTransient, "request canceled while waiting to retry", sleepErr)
+					return nil, nil, apperrors.New(apperrors.KindTransient, "request canceled while waiting to retry", sleepErr)
 				}
 				continue
 			}
 			client.logger.Error("http request returned error status", fields)
-			return lastErr
+			return nil, nil, lastErr
 		}
 
 		client.logger.Error("http request returned error status", fields)
 
-		return mappedErr
+		return nil, nil, mappedErr
 	}
 
 	if lastErr != nil {
-		return lastErr
+		return nil, nil, lastErr
 	}
 
-	return apperrors.New(apperrors.KindTransient, "request failed after retries", nil)
+	return nil, nil, apperrors.New(apperrors.KindTransient, "request failed after retries", nil)
 }
 
 func (client *Client) Health(ctx context.Context) (HealthStatus, error) {

--- a/internal/transport/httpclient/client_test.go
+++ b/internal/transport/httpclient/client_test.go
@@ -609,3 +609,163 @@ func TestDiagnosticsWriter(t *testing.T) {
 		t.Fatalf("expected discard writer when disabled, got %T", writer)
 	}
 }
+
+func TestGetRawReturnsBodyVerbatim(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/rest/api/latest/projects/TEST/repos/demo/raw/dir/file.txt" {
+			http.NotFound(writer, request)
+			return
+		}
+		if request.URL.Query().Get("at") != "refs/heads/main" {
+			writer.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		// GetRaw must not ask for JSON: the endpoint streams file contents.
+		if request.Header.Get("Accept") != "" {
+			writer.WriteHeader(http.StatusNotAcceptable)
+			return
+		}
+		writer.Header().Set("Content-Type", "text/plain")
+		_, _ = writer.Write([]byte("line one\nline two\n"))
+	}))
+	defer server.Close()
+
+	client := NewFromConfig(config.AppConfig{BitbucketURL: server.URL})
+
+	body, err := client.GetRaw(
+		context.Background(),
+		"/rest/api/latest/projects/TEST/repos/demo/raw/dir/file.txt",
+		map[string]string{"at": "refs/heads/main"},
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if string(body) != "line one\nline two\n" {
+		t.Fatalf("expected verbatim body, got %q", string(body))
+	}
+}
+
+func TestGetRawMapsStatusErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+		_, _ = writer.Write([]byte(`{"errors":[{"message":"file not found"}]}`))
+	}))
+	defer server.Close()
+
+	client := NewFromConfig(config.AppConfig{BitbucketURL: server.URL})
+
+	_, err := client.GetRaw(context.Background(), "/rest/api/latest/missing", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if apperrors.ExitCode(err) != 4 {
+		t.Fatalf("expected not-found exit code 4, got %d: %v", apperrors.ExitCode(err), err)
+	}
+}
+
+func TestGetRawRetriesServerErrors(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if calls.Add(1) == 1 {
+			writer.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = writer.Write([]byte("recovered"))
+	}))
+	defer server.Close()
+
+	client := NewFromConfig(config.AppConfig{
+		BitbucketURL: server.URL,
+		RetryCount:   2,
+		RetryBackoff: time.Millisecond,
+	})
+
+	body, err := client.GetRaw(context.Background(), "/rest/api/latest/flaky", nil)
+	if err != nil {
+		t.Fatalf("expected retry to succeed, got: %v", err)
+	}
+	if string(body) != "recovered" {
+		t.Fatalf("expected recovered body, got %q", string(body))
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", calls.Load())
+	}
+}
+
+func TestGetRawTransientNetworkFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		hijacker, ok := writer.(http.Hijacker)
+		if !ok {
+			http.Error(writer, "hijacking unsupported", http.StatusInternalServerError)
+			return
+		}
+		connection, _, err := hijacker.Hijack()
+		if err == nil {
+			_ = connection.Close()
+		}
+	}))
+	defer server.Close()
+
+	client := NewFromConfig(config.AppConfig{BitbucketURL: server.URL})
+
+	if _, err := client.GetRaw(context.Background(), "/rest/api/latest/dropped", nil); err == nil || apperrors.ExitCode(err) != 10 {
+		t.Fatalf("expected transient exit code 10, got %v", err)
+	}
+}
+
+func TestCurrentUserSlugReadsResponseHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/rest/api/latest/users" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("X-AUSERNAME", " alice ")
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"values":[]}`))
+	}))
+	defer server.Close()
+
+	client := NewFromConfig(config.AppConfig{BitbucketURL: server.URL})
+
+	slug, err := client.CurrentUserSlug(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if slug != "alice" {
+		t.Fatalf("expected trimmed slug alice, got %q", slug)
+	}
+}
+
+func TestCurrentUserSlugMissingHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"values":[]}`))
+	}))
+	defer server.Close()
+
+	client := NewFromConfig(config.AppConfig{BitbucketURL: server.URL})
+
+	_, err := client.CurrentUserSlug(context.Background())
+	if err == nil {
+		t.Fatal("expected error when the header is absent")
+	}
+	if !strings.Contains(err.Error(), "X-AUSERNAME") {
+		t.Fatalf("expected the error to name the missing header, got: %v", err)
+	}
+	if apperrors.ExitCode(err) != 3 {
+		t.Fatalf("expected authentication exit code 3, got %d", apperrors.ExitCode(err))
+	}
+}
+
+func TestCurrentUserSlugPropagatesStatusErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewFromConfig(config.AppConfig{BitbucketURL: server.URL})
+
+	if _, err := client.CurrentUserSlug(context.Background()); err == nil || apperrors.ExitCode(err) != 3 {
+		t.Fatalf("expected authentication exit code 3, got %v", err)
+	}
+}

--- a/skills/bb/SKILL.md
+++ b/skills/bb/SKILL.md
@@ -305,17 +305,19 @@ bb ai mcp serve --tools get_pull_request,list_pr_comments,get_build_status
 | `list_required_builds` | What CI must pass before merging |
 | `get_repository_clone_info` | HTTPS and SSH clone URLs |
 | `resolve_ref` | Check branch/tag exists, get tip SHA |
-| `list_pull_requests` | Open PRs on a repo |
+| `list_pull_requests` | PRs on a repo, or your own PRs across all repos when `project`/`repo` are omitted |
 | `create_pull_request` | Open a PR (supports `draft`) |
 | `enable_auto_merge` | Auto-merge a PR once checks pass |
 | `disable_auto_merge` | Cancel auto-merge on a PR |
-| `add_pr_comment` | Post a review comment |
+| `add_pr_comment` | Post a review comment, inline on a line (`path` + `line`) or as a reply (`parent_id`) |
+| `get_pr_diff` | Unified diff of a PR |
+| `get_file_content` | Raw contents of a file at a ref |
 | `list_branches` | All branches, with optional filter |
 | `list_tags` | All tags |
 | `compare_refs` | Commits between two refs |
 | `list_commits` | Walk commit history |
 | `get_commit` | Single commit details |
-| `submit_pr_review` | Approve or unapprove a PR |
+| `submit_pr_review` | Approve, unapprove, or request changes (`needs_work`) |
 | `merge_pull_request` | Merge when ready |
 | `create_tag` | Tag a commit for release |
 | `set_build_status` | Report CI results back to Bitbucket |


### PR DESCRIPTION
Picks up [#286](https://github.com/vriesdemichael/bitbucket-data-center-cli/pull/286) by @xiedewei and carries it over the line. Their commit is preserved as-is with original authorship; the follow-up commits address the review feedback.

## What the original PR brings

- `httpclient.GetRaw` and `CurrentUserSlug` (via the `X-AUSERNAME` response header, replacing a temp-comment hack that wrote to the server just to learn who you are)
- Fixes browse `raw`/`file`: the generated OpenAPI client escapes `/` in the path parameter to `%2F`, which Bitbucket's wildcard endpoints reject
- New MCP tools `get_pr_diff` and `get_file_content`
- `list_pull_requests` gains dashboard mode and a role filter; `add_pr_comment` gains inline comments and replies; `submit_pr_review` gains `needs_work`
- PR service methods `NeedsWork`, `AddComment`, `AddInlineComment`
- Uses the `reviewers` field with a `participants` fallback — on Bitbucket Data Center 9.4.16 `participants` comes back empty and only `reviewers` is populated. Good field report; that one is hard to find without hitting a real instance.

## What the follow-up commits change

**Path escaping (security).** `Raw` and `File` interpolated the caller's path straight into the request URL. A path containing `?` or `#` reshaped the request and `..` reached a different REST endpoint. `get_file_content` takes that path from a model, so it was reachable input. Paths are now escaped per segment — `/` still survives as a real separator, which was the point of the original fix — and `..` is rejected.

**`Tree` had the same `%2F` bug.** `/files` also takes the directory as a trailing wildcard, so `bb repo browse tree src/main/java` was requesting `files/src%2Fmain%2Fjava`. It now shares the escaping helper, which also let the dual generated-client branches and the manual status mapping go.

**Transport dedup.** `GetRaw` was a near-verbatim copy of `doJSON`'s retry, logging and error-mapping — about 90 lines. Both now share a single `do()` returning body and headers, so raw and JSON requests cannot drift apart. `CurrentUserSlug` uses it too and gains retries.

**Content negotiation.** Routing `File` through `GetRaw` would have dropped the `Accept: application/json` header the generated client sent, and `/browse` answers with JSON. It goes through `GetJSON` into a `json.RawMessage`: same undecoded bytes to the caller, correct negotiation on the wire. Only `/raw`, which streams file bytes, goes without an Accept header.

**Argument validation.** `add_pr_comment` rejected nothing before: a `line` without a `path`, a `path` without a `line`, `parent_id` combined with an anchor, or a `line_type` with no anchor all silently produced a plain top-level comment. For a model-facing tool that means the comment lands somewhere other than intended with no signal. All four are now errors, and `line_type` is validated against `ADDED`/`REMOVED`/`CONTEXT`.

**Inline anchors** now send `fileType` (`FROM` for removed lines, `TO` otherwise) and `diffType: EFFECTIVE` so they attach against the pull request diff rather than a single commit.

**Housekeeping.** Dropped an unused `baseURL` threaded through `browse.NewService` and its six call sites; corrected the `NeedsWork` doc comment, which still described the removed hack; restored the `participants` test fixtures and covered the `reviewers` fallback separately so both branches of `mapReviewers` are exercised; updated the MCP tool catalogue in `skills/bb/SKILL.md`.

## Verification

Build, vet and the full unit suite pass. Patch coverage **95.0%** against the 85% gate; combined scoped coverage 89.6%.

## One thing worth a second opinion

`diffType: EFFECTIVE` and the `fileType` derivation follow Atlassian's documented anchor semantics, but I have no 9.4.16 instance to confirm against. If inline comments land in the wrong place on a real server, that pair is the first thing to check.
