### PR TITLE
fix(git): scope git subprocesses by working directory, not ambient GIT_DIR

### DIFF
--- a/internal/git/execgit/backend.go
+++ b/internal/git/execgit/backend.go
@@ -230,6 +230,7 @@ func (backend *Backend) run(ctx context.Context, options runOptions) (runResult,
 	if options.cwd != "" {
 		command.Dir = options.cwd
 	}
+	command.Env = ScopeFreeEnv()
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/git/execgit/env.go
+++ b/internal/git/execgit/env.go
@@ -1,0 +1,49 @@
+package execgit
+
+import (
+	"os"
+	"slices"
+	"strings"
+)
+
+// repositoryScopeVars are the environment variables git uses to locate the
+// repository it acts on. Git honours them over the process working directory,
+// so a command with Dir set to one repository still reads and writes whatever
+// these point at.
+//
+// Git exports them to every hook it runs. Inheriting them means a git command
+// issued from inside a hook — or from any tool invoked by one — silently
+// operates on the hook's repository rather than the directory it was pointed
+// at.
+var repositoryScopeVars = []string{
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_COMMON_DIR",
+	"GIT_PREFIX",
+	"GIT_NAMESPACE",
+	"GIT_CEILING_DIRECTORIES",
+}
+
+// ScopeFreeEnv returns the process environment with git's repository-scoping
+// variables removed, so a git command is scoped by its working directory alone.
+//
+// Use it for any git subprocess that targets a specific directory. Everything
+// else in the environment is preserved, including credential and proxy
+// configuration.
+func ScopeFreeEnv() []string {
+	environment := os.Environ()
+	filtered := make([]string, 0, len(environment))
+
+	for _, entry := range environment {
+		name, _, found := strings.Cut(entry, "=")
+		if found && slices.Contains(repositoryScopeVars, name) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+
+	return filtered
+}

--- a/internal/git/execgit/env_test.go
+++ b/internal/git/execgit/env_test.go
@@ -1,0 +1,134 @@
+package execgit
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// These tests must not assume the ambient environment is free of git's
+// repository-scoping variables: git exports them to every hook it runs, and the
+// suite is itself run from a pre-push hook. Any git command here therefore
+// passes an explicit environment rather than inheriting one.
+
+func TestScopeFreeEnvRemovesRepositoryScopeVars(t *testing.T) {
+	for _, name := range repositoryScopeVars {
+		t.Setenv(name, "/somewhere/else")
+	}
+	t.Setenv("BB_EXECGIT_SENTINEL", "kept")
+
+	filtered := ScopeFreeEnv()
+
+	for _, name := range repositoryScopeVars {
+		if containsEnvVar(filtered, name) {
+			t.Errorf("%s must be stripped so git is scoped by the working directory alone", name)
+		}
+	}
+
+	if !containsEnvVar(filtered, "BB_EXECGIT_SENTINEL") {
+		t.Error("unrelated environment variables must be preserved")
+	}
+}
+
+// TestScopeFreeEnvPreservesEverythingElse pins that filtering removes only the
+// scoping variables, so credential and proxy configuration still reaches git.
+func TestScopeFreeEnvPreservesEverythingElse(t *testing.T) {
+	t.Setenv("GIT_DIR", "/somewhere/else/.git")
+	t.Setenv("GIT_TERMINAL_PROMPT", "0")
+	t.Setenv("HTTPS_PROXY", "http://proxy.example:3128")
+
+	filtered := ScopeFreeEnv()
+
+	// Compare against the actual environment rather than a fixed count: more
+	// scoping variables may already be present when running under a hook.
+	for _, entry := range os.Environ() {
+		name, _, found := strings.Cut(entry, "=")
+		if !found || slices.Contains(repositoryScopeVars, name) {
+			continue
+		}
+		if !containsEnvVar(filtered, name) {
+			t.Errorf("%s is not repository-scoping and must be preserved", name)
+		}
+	}
+
+	if containsEnvVar(filtered, "GIT_DIR") {
+		t.Error("GIT_DIR must be stripped")
+	}
+	if !containsEnvVar(filtered, "GIT_TERMINAL_PROMPT") {
+		t.Error("GIT_TERMINAL_PROMPT is not repository-scoping and must be preserved")
+	}
+}
+
+// TestScopeFreeEnvIsolatesGitFromAnAmbientRepository is the behavioural check:
+// with GIT_DIR pointing at another repository, a git command run with the
+// filtered environment must still resolve the one in its working directory.
+func TestScopeFreeEnvIsolatesGitFromAnAmbientRepository(t *testing.T) {
+	decoy := t.TempDir()
+	target := t.TempDir()
+
+	// Initialise with a scrubbed environment so an ambient GIT_DIR cannot
+	// redirect the setup itself.
+	runGitIn(t, ScopeFreeEnv(), decoy, "init")
+	runGitIn(t, ScopeFreeEnv(), target, "init")
+
+	t.Setenv("GIT_DIR", filepath.Join(decoy, ".git"))
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(decoy, ".git", "index"))
+
+	resolved := runGitIn(t, ScopeFreeEnv(), target, "rev-parse", "--absolute-git-dir")
+
+	if !sameDir(t, resolved, filepath.Join(target, ".git")) {
+		t.Errorf("git resolved %q, want the repository in %q", resolved, target)
+	}
+	if sameDir(t, resolved, filepath.Join(decoy, ".git")) {
+		t.Errorf("git followed the ambient GIT_DIR and resolved %q", resolved)
+	}
+}
+
+// sameDir compares two paths tolerating separator, symlink and case
+// differences, which all vary across the platforms this suite runs on.
+func sameDir(t *testing.T, a, b string) bool {
+	t.Helper()
+
+	normalize := func(p string) string {
+		if resolved, err := filepath.EvalSymlinks(p); err == nil {
+			p = resolved
+		}
+		return strings.ToLower(filepath.ToSlash(filepath.Clean(p)))
+	}
+
+	return normalize(a) == normalize(b)
+}
+
+// runGitIn runs git in dir with an explicit environment and returns trimmed
+// output, skipping the test if git is unavailable.
+func runGitIn(t *testing.T, environment []string, dir string, args ...string) string {
+	t.Helper()
+
+	command := exec.Command("git", args...)
+	command.Dir = dir
+	command.Env = environment
+
+	output, err := command.CombinedOutput()
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			t.Skip("git is not available")
+		}
+		t.Fatalf("git %s in %s failed: %v: %s", strings.Join(args, " "), dir, err, output)
+	}
+
+	return strings.TrimSpace(string(output))
+}
+
+func containsEnvVar(environment []string, name string) bool {
+	prefix := name + "="
+	for _, entry := range environment {
+		if strings.HasPrefix(entry, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/integration/live/harness_git_env_test.go
+++ b/tests/integration/live/harness_git_env_test.go
@@ -1,0 +1,59 @@
+//go:build live
+
+package live_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/git/execgit"
+)
+
+// TestScopeFreeEnvStripsRepositoryScope guards against git commands being
+// retargeted at whatever repository the process happens to be running under.
+//
+// Git exports GIT_DIR and friends to the hooks it runs, and honours them over a
+// command's working directory. Before these were stripped, running the live
+// suite from a pre-push hook seeded fixtures into the developer's own
+// repository, committing onto the branch being pushed.
+func TestScopeFreeEnvStripsRepositoryScope(t *testing.T) {
+	scoped := map[string]string{
+		"GIT_DIR":        "/somewhere/else/.git",
+		"GIT_INDEX_FILE": "/somewhere/else/.git/index",
+		"GIT_WORK_TREE":  "/somewhere/else",
+		"GIT_PREFIX":     "sub/dir/",
+	}
+	for name, value := range scoped {
+		t.Setenv(name, value)
+	}
+	t.Setenv("BB_HARNESS_SENTINEL", "kept")
+
+	filtered := execgit.ScopeFreeEnv()
+
+	for name := range scoped {
+		if hasEnvVar(filtered, name) {
+			t.Errorf("%s must be stripped so git is scoped by the working directory alone", name)
+		}
+	}
+
+	if !hasEnvVar(filtered, "BB_HARNESS_SENTINEL") {
+		t.Error("unrelated environment variables must be preserved")
+	}
+
+	// Not an exact count: the suite runs from a pre-push hook, where git has
+	// already exported scoping variables beyond the ones set above.
+	if len(filtered) > len(os.Environ())-len(scoped) {
+		t.Errorf("expected at least the scoping variables to be removed: got %d of %d", len(filtered), len(os.Environ()))
+	}
+}
+
+func hasEnvVar(environment []string, name string) bool {
+	prefix := name + "="
+	for _, entry := range environment {
+		if strings.HasPrefix(entry, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/integration/live/harness_test.go
+++ b/tests/integration/live/harness_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/vriesdemichael/bitbucket-server-cli/internal/config"
+	"github.com/vriesdemichael/bitbucket-server-cli/internal/git/execgit"
 	openapigenerated "github.com/vriesdemichael/bitbucket-server-cli/internal/openapi/generated"
 )
 
@@ -413,7 +414,7 @@ func runGit(directory string, args ...string) error {
 		gitArgs := append([]string{"-c", "credential.helper="}, args...)
 		command := exec.Command("git", gitArgs...)
 		command.Dir = directory
-		command.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+		command.Env = append(execgit.ScopeFreeEnv(), "GIT_TERMINAL_PROMPT=0")
 		output, err := command.CombinedOutput()
 		if err == nil {
 			return nil


### PR DESCRIPTION
`execgit` set `command.Dir` but never set `command.Env`, so every git subprocess inherited `GIT_DIR`, `GIT_INDEX_FILE` and friends. Git honours those **over** the working directory, so a git-backed command run in an environment that has them set operates on the wrong repository.

Git exports them to every hook it runs, which makes this reachable in normal use: `bb` invoked from a git hook, or from a script a hook calls, silently targets the hook's repository instead of the directory it was given.

## How it surfaced

The live suite seeds fixtures over git, and the pre-push hook runs it via `task quality:coverage:origin-main`. Under the hook, seeding wrote into the repository being pushed — committing a `seed` fixture onto the branch under test — and the tests then failed because the fixture they asserted on was never created where they looked.

Two consequences worth calling out:

- **The pre-push hook could not pass on any branch.** Not specific to any change; `task quality:coverage:origin-main` failed for everyone, every time.
- **It did not reproduce standalone.** Running the same task directly passed, because the variables only exist under a hook. That is what made it hard to place.

## The fix

`execgit.ScopeFreeEnv()` drops the repository-scoping variables and preserves everything else, including credential and proxy configuration. Used by both the CLI's git calls and the live harness's seeding, so there is one definition rather than two.

## Tests

Three unit tests in the normal suite, plus one live-tagged regression test. The behavioural one points `GIT_DIR` at a decoy repository and asserts git still resolves the one in the working directory.

The tests are written to pass with **and** without ambient `GIT_*` variables — an earlier revision of them assumed a clean environment and failed under the hook, which is the same fragility this PR is about.

## Verification

The pre-push hook now passes (`02-coverage`, 490s) and the branch pushed with `HEAD` intact. Before the fix, the same push corrupted the branch twice.
